### PR TITLE
Improve CI check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Summary
- Rename CI check names from `test (18)` to `Test (Node 18)` for better readability in PR status checks

## Test plan
- Verify CI runs and check names display correctly