### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laint",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "AI Agent Lint Rules SDK - programmatic JSX/TSX linting for AI code generation",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump package version from 0.1.2 to 0.1.3

## Post-merge
Tag `v0.1.3` after merging to trigger the publish workflow.