### PR TITLE
Add repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "code-generation",
     "ast"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Create-Inc/laint"
+  },
   "license": "MIT",
   "dependencies": {
     "@babel/parser": "^7.24.0",


### PR DESCRIPTION
## Summary
- Add `repository.url` to package.json pointing to `https://github.com/Create-Inc/laint`

## Context
The v0.1.3 publish failed because `npm publish --provenance` requires `repository.url` to match the GitHub repo for sigstore verification. Without it, npm returns E422.

## Post-merge
Delete the old `v0.1.3` tag and re-tag to trigger a new publish:
```
git tag -d v0.1.3 && git push origin :refs/tags/v0.1.3
git checkout main && git pull
git tag v0.1.3 && git push origin v0.1.3
```