### PR TITLE
Add CLI with Claude Code hook integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Test (Node ${{ matrix.node-version }})
+    name: Unit Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
 
     strategy:
@@ -33,11 +33,37 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: CLI smoke test
+  cli-smoke-test:
+    name: CLI Smoke Test
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: laint check (file mode)
         run: |
           echo '<div />' > /tmp/clean.tsx
           node dist/cli.js check /tmp/clean.tsx
+
+      - name: laint check --hook (stdin mode)
+        run: |
+          echo '<div />' > /tmp/clean.tsx
           echo '{"tool_input":{"file_path":"/tmp/clean.tsx"}}' | node dist/cli.js check --hook
+
+      - name: laint init
+        run: |
           node dist/cli.js init
           test -f .claude/settings.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: CLI smoke test
+        run: |
+          echo '<div />' > /tmp/clean.tsx
+          node dist/cli.js check /tmp/clean.tsx
+          echo '{"tool_input":{"file_path":"/tmp/clean.tsx"}}' | node dist/cli.js check --hook
+          node dist/cli.js init
+          test -f .claude/settings.json
+
+      - name: Package dry-run
+        run: npm pack --dry-run 2>&1 | tee /dev/stderr | grep -q 'dist/cli.js'
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,13 +2,53 @@
 
 AI Agent Lint Rules SDK - a simple programmatic API for linting JSX/TSX code.
 
+## Claude Code Integration
+
+The fastest way to use laint is as a [Claude Code hook](https://docs.anthropic.com/en/docs/claude-code/hooks). After every file edit, Claude sees lint violations and fixes them automatically.
+
+```bash
+npx laint init
+```
+
+This writes a `.claude/settings.json` with a `PostToolUse` hook that runs after every `Edit` and `Write` tool call. If the file already exists, it merges without clobbering your other settings.
+
+### Configuring Rules
+
+By default, all 31 rules run. To customize, create a `laint.config.json` in your project root:
+
+```json
+// Only run these specific rules (include mode)
+{ "rules": ["no-relative-paths", "expo-image-import", "fetch-response-ok-check"] }
+```
+
+```json
+// Run all rules except these (exclude mode)
+{ "rules": ["no-tailwind-animation-classes", "no-stylesheet-create"], "exclude": true }
+```
+
+### CLI
+
+```bash
+# Lint a file directly
+npx laint check src/components/Button.tsx
+
+# Hook mode (used by Claude Code automatically — reads stdin JSON)
+npx laint check --hook
+```
+
+**Exit codes:**
+
+- `0` — clean (no violations)
+- `1` — violations found (file mode)
+- `2` — violations found (hook mode, stderr output for Claude)
+
 ## Installation
 
 ```bash
 npm install laint
 ```
 
-## Usage
+## Programmatic Usage
 
 ```typescript
 import { lintJsxCode, getAllRuleNames } from 'laint';
@@ -404,6 +444,8 @@ Returns an array of all available rule names.
 
 ```bash
 npm install     # Install dependencies
-npm test        # Run tests (196 tests)
+npm test        # Run tests (213 tests)
 npm run build   # Build TypeScript
+npm run lint    # ESLint + Prettier
+npm run knip    # Dead code detection
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "laint",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "laint",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",
         "@babel/traverse": "^7.24.0"
+      },
+      "bin": {
+        "laint": "dist/cli.js"
       },
       "devDependencies": {
         "@babel/types": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "AI Agent Lint Rules SDK - programmatic JSX/TSX linting for AI code generation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "laint": "./dist/cli.js"
+  },
   "files": [
     "dist"
   ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { runInit } from './cli/init';
+import { runCheck } from './cli/check';
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function main(): Promise<void> {
+  if (command === 'init') {
+    runInit();
+  } else if (command === 'check') {
+    await runCheck(args.slice(1));
+  } else {
+    console.error(`Usage: laint <command>
+
+Commands:
+  init           Set up Claude Code hook for automatic linting
+  check <file>   Lint a JSX/TSX file
+  check --hook   Lint via Claude Code hook (reads stdin)`);
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,0 +1,121 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { lintJsxCode } from '../index';
+import type { LintConfig, LintResult } from '../types';
+
+const JSX_EXTENSIONS = new Set(['.jsx', '.tsx']);
+
+function loadConfig(): LintConfig {
+  const configPath = path.resolve('laint.config.json');
+  if (fs.existsSync(configPath)) {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    return JSON.parse(raw) as LintConfig;
+  }
+  // Default: run all rules
+  return { rules: [], exclude: true };
+}
+
+function formatResult(filePath: string, r: LintResult): string {
+  return `${filePath}:${String(r.line)}:${String(r.column)} ${r.severity} [${r.rule}] ${r.message}`;
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    process.stdin.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf-8'));
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+async function runHookMode(): Promise<void> {
+  let input: string;
+  try {
+    input = await readStdin();
+  } catch {
+    // Can't read stdin — don't block Claude
+    process.exit(0);
+  }
+
+  let filePath: string;
+  try {
+    const data = JSON.parse(input) as { tool_input?: { file_path?: string } };
+    filePath = data.tool_input?.file_path ?? '';
+  } catch {
+    // Malformed JSON — don't block Claude
+    process.exit(0);
+  }
+
+  if (!filePath) {
+    process.exit(0);
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  if (!JSX_EXTENSIONS.has(ext)) {
+    process.exit(0);
+  }
+
+  let code: string;
+  try {
+    code = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    // File doesn't exist or can't be read — don't block Claude
+    process.exit(0);
+  }
+
+  const config = loadConfig();
+  let results: LintResult[];
+  try {
+    results = lintJsxCode(code, config);
+  } catch {
+    // Parse error or rule error — don't block Claude
+    process.exit(0);
+  }
+
+  if (results.length === 0) {
+    process.exit(0);
+  }
+
+  const output = results.map((r) => formatResult(filePath, r)).join('\n');
+  process.stderr.write(output + '\n');
+  process.exit(2);
+}
+
+function runFileMode(filePath: string): void {
+  if (!fs.existsSync(filePath)) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const code = fs.readFileSync(filePath, 'utf-8');
+  const config = loadConfig();
+  const results = lintJsxCode(code, config);
+
+  if (results.length === 0) {
+    process.exit(0);
+  }
+
+  for (const r of results) {
+    console.log(formatResult(filePath, r));
+  }
+  process.exit(1);
+}
+
+export async function runCheck(args: string[]): Promise<void> {
+  if (args.includes('--hook')) {
+    await runHookMode();
+    return;
+  }
+
+  const filePath = args[0];
+  if (!filePath) {
+    console.error('Usage: laint check <file> or laint check --hook');
+    process.exit(1);
+  }
+
+  runFileMode(filePath);
+}

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const HOOK_COMMAND = 'npx laint check --hook';
+
+interface HookEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+
+interface MatcherEntry {
+  matcher: string;
+  hooks: HookEntry[];
+}
+
+interface SettingsJson {
+  hooks?: {
+    PostToolUse?: MatcherEntry[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+function hasLaintHook(settings: SettingsJson): boolean {
+  const postToolUse = settings.hooks?.PostToolUse;
+  if (!Array.isArray(postToolUse)) return false;
+
+  return postToolUse.some((entry: MatcherEntry) =>
+    entry.hooks?.some((h: HookEntry) => h.command === HOOK_COMMAND),
+  );
+}
+
+export function runInit(): void {
+  const claudeDir = path.resolve('.claude');
+  const settingsPath = path.join(claudeDir, 'settings.json');
+
+  const laintHookEntry: MatcherEntry = {
+    matcher: 'Edit|Write',
+    hooks: [
+      {
+        type: 'command',
+        command: HOOK_COMMAND,
+        timeout: 30,
+      },
+    ],
+  };
+
+  let settings: SettingsJson = {};
+
+  if (fs.existsSync(settingsPath)) {
+    const raw = fs.readFileSync(settingsPath, 'utf-8');
+    settings = JSON.parse(raw) as SettingsJson;
+
+    if (hasLaintHook(settings)) {
+      console.log('laint hook already configured in .claude/settings.json — skipping.');
+      return;
+    }
+  }
+
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+  if (!Array.isArray(settings.hooks.PostToolUse)) {
+    settings.hooks.PostToolUse = [];
+  }
+
+  settings.hooks.PostToolUse.push(laintHookEntry);
+
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+  console.log('Created .claude/settings.json with laint PostToolUse hook.');
+  console.log('Claude Code will now lint JSX/TSX files after every Edit and Write.');
+}

--- a/tests/cli-check.test.ts
+++ b/tests/cli-check.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const CLI_PATH = path.resolve('dist/cli.js');
+
+interface ExecError {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function run(args: string[], options?: { input?: string; cwd?: string }) {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      input: options?.input,
+      cwd: options?.cwd,
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as ExecError;
+    return {
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+      exitCode: e.status,
+    };
+  }
+}
+
+describe('laint check', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'laint-check-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('file mode', () => {
+    it('should report violations for a file with issues', () => {
+      const file = path.join(tmpDir, 'bad.tsx');
+      fs.writeFileSync(file, `import { Image } from 'react-native';\n`);
+      const result = run(['check', file]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('expo-image-import');
+      expect(result.stdout).toContain(file);
+    });
+
+    it('should exit 0 for a clean file', () => {
+      const file = path.join(tmpDir, 'clean.tsx');
+      fs.writeFileSync(file, `export const Foo = () => <div>hello</div>;\n`);
+      const result = run(['check', file]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+    });
+
+    it('should exit 1 with error for missing file', () => {
+      const result = run(['check', path.join(tmpDir, 'nope.tsx')]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('File not found');
+    });
+
+    it('should output file:line:col severity [rule] message format', () => {
+      const file = path.join(tmpDir, 'format.tsx');
+      fs.writeFileSync(file, `import { Image } from 'react-native';\n`);
+      const result = run(['check', file]);
+      const line = result.stdout.trim().split('\n')[0];
+      // format: filepath:line:col severity [rule] message
+      expect(line).toMatch(/^.+:\d+:\d+ \w+ \[[\w-]+\] .+$/);
+    });
+
+    it('should respect laint.config.json', () => {
+      const file = path.join(tmpDir, 'test.tsx');
+      // This file triggers expo-image-import rule
+      fs.writeFileSync(file, `import { Image } from 'react-native';\n`);
+
+      // Config that only enables a different rule — should find no violations
+      fs.writeFileSync(
+        path.join(tmpDir, 'laint.config.json'),
+        JSON.stringify({ rules: ['no-relative-paths'] }),
+      );
+
+      const result = run(['check', file], { cwd: tmpDir });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('hook mode (--hook)', () => {
+    it('should lint file from stdin JSON and report violations on stderr', () => {
+      const file = path.join(tmpDir, 'hook-bad.tsx');
+      fs.writeFileSync(file, `import { Image } from 'react-native';\n`);
+
+      const input = JSON.stringify({ tool_input: { file_path: file } });
+      const result = run(['check', '--hook'], { input });
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('expo-image-import');
+    });
+
+    it('should exit 0 silently for clean file', () => {
+      const file = path.join(tmpDir, 'hook-clean.tsx');
+      fs.writeFileSync(file, `export const Foo = () => <div>ok</div>;\n`);
+
+      const input = JSON.stringify({ tool_input: { file_path: file } });
+      const result = run(['check', '--hook'], { input });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe('');
+    });
+
+    it('should skip non-JSX/TSX files silently', () => {
+      const file = path.join(tmpDir, 'script.ts');
+      fs.writeFileSync(file, `console.log('hello');\n`);
+
+      const input = JSON.stringify({ tool_input: { file_path: file } });
+      const result = run(['check', '--hook'], { input });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should skip when file_path is missing', () => {
+      const input = JSON.stringify({ tool_input: {} });
+      const result = run(['check', '--hook'], { input });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should handle malformed JSON gracefully', () => {
+      const result = run(['check', '--hook'], { input: 'not json' });
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should handle missing file gracefully', () => {
+      const input = JSON.stringify({ tool_input: { file_path: '/tmp/nonexistent.tsx' } });
+      const result = run(['check', '--hook'], { input });
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('no arguments', () => {
+    it('should print usage and exit 1 when no file given', () => {
+      const result = run(['check']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Usage');
+    });
+  });
+});

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -1,0 +1,165 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const CLI_PATH = path.resolve('dist/cli.js');
+
+interface ExecError {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+interface HookEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+
+interface MatcherEntry {
+  matcher: string;
+  hooks: HookEntry[];
+}
+
+interface SettingsJson {
+  permissions?: { allow: string[] };
+  hooks?: {
+    PreToolUse?: MatcherEntry[];
+    PostToolUse?: MatcherEntry[];
+  };
+}
+
+function run(args: string[], options?: { cwd?: string }) {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      cwd: options?.cwd,
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as ExecError;
+    return {
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+      exitCode: e.status,
+    };
+  }
+}
+
+function readSettings(tmpDir: string): SettingsJson {
+  const raw = fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8');
+  return JSON.parse(raw) as SettingsJson;
+}
+
+describe('laint init', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'laint-init-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should create .claude/settings.json when it does not exist', () => {
+    const result = run(['init'], { cwd: tmpDir });
+    expect(result.exitCode).toBe(0);
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    expect(fs.existsSync(settingsPath)).toBe(true);
+
+    const settings = readSettings(tmpDir);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+    expect(settings.hooks?.PostToolUse?.[0].matcher).toBe('Edit|Write');
+    expect(settings.hooks?.PostToolUse?.[0].hooks[0].command).toBe('npx laint check --hook');
+    expect(settings.hooks?.PostToolUse?.[0].hooks[0].timeout).toBe(30);
+  });
+
+  it('should merge into existing .claude/settings.json without clobbering', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    const existing = {
+      permissions: { allow: ['Read'] },
+      hooks: {
+        PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'echo pre' }] }],
+      },
+    };
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    const result = run(['init'], { cwd: tmpDir });
+    expect(result.exitCode).toBe(0);
+
+    const settings = readSettings(tmpDir);
+    // Existing settings preserved
+    expect(settings.permissions?.allow).toEqual(['Read']);
+    expect(settings.hooks?.PreToolUse).toHaveLength(1);
+    // laint hook added
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+    expect(settings.hooks?.PostToolUse?.[0].hooks[0].command).toBe('npx laint check --hook');
+  });
+
+  it('should skip if laint hook already present', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    const existing = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit|Write',
+            hooks: [{ type: 'command', command: 'npx laint check --hook', timeout: 30 }],
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    const result = run(['init'], { cwd: tmpDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('already configured');
+
+    // Should not duplicate the hook
+    const settings = readSettings(tmpDir);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+  });
+
+  it('should be idempotent — running twice is safe', () => {
+    run(['init'], { cwd: tmpDir });
+    const result = run(['init'], { cwd: tmpDir });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('already configured');
+
+    const settings = readSettings(tmpDir);
+    expect(settings.hooks?.PostToolUse).toHaveLength(1);
+  });
+
+  it('should append to existing PostToolUse hooks', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+
+    const existing = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: 'echo done' }],
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    const result = run(['init'], { cwd: tmpDir });
+    expect(result.exitCode).toBe(0);
+
+    const settings = readSettings(tmpDir);
+    expect(settings.hooks?.PostToolUse).toHaveLength(2);
+    expect(settings.hooks?.PostToolUse?.[0].matcher).toBe('Bash');
+    expect(settings.hooks?.PostToolUse?.[1].matcher).toBe('Edit|Write');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `npx laint init` command that sets up a Claude Code `PostToolUse` hook in `.claude/settings.json` — Claude automatically lints JSX/TSX files after every Edit/Write and fixes violations
- Adds `npx laint check <file>` for direct file linting and `npx laint check --hook` for stdin-based hook mode
- Supports `laint.config.json` for toggling which rules run (include or exclude mode)
- Updates README with Claude Code integration docs and CLI usage

## New files

| File | Purpose |
|------|---------|
| `src/cli.ts` | CLI entrypoint (shebang, arg parsing, subcommand dispatch) |
| `src/cli/init.ts` | `laint init` — creates/merges `.claude/settings.json` with hook |
| `src/cli/check.ts` | `laint check` — file mode + hook stdin mode |
| `tests/cli-check.test.ts` | 12 tests for check subcommand |
| `tests/cli-init.test.ts` | 5 tests for init subcommand |

## Test plan

- [x] `npm run build` — compiles cleanly, shebang preserved, ESM imports fixed
- [x] `npm test` — 213/213 tests pass (34 files)
- [x] `npm run lint` — 0 errors (only expected security warnings for dynamic fs paths)
- [x] `npm run knip` — clean, no unused exports
- [x] Manual: `node dist/cli.js check <file>` works
- [x] Manual: `echo '...' | node dist/cli.js check --hook` works
- [x] Manual: `node dist/cli.js init` creates correct settings