### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laint",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "AI Agent Lint Rules SDK - programmatic JSX/TSX linting for AI code generation",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 for npm publish with CLI support

## Test plan
- CI passes
- After merge, push `v0.1.4` tag to trigger publish workflow