### PR TITLE
Add auto-tag workflow for automated publishing

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,39 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths: [package.json]
+
+jobs:
+  tag:
+    name: Tag version
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for version change
+        id: version
+        run: |
+          NEW=$(node -p "require('./package.json').version")
+          OLD=$(git show HEAD~1:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+          if [ "$NEW" != "$OLD" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v$NEW" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $OLD -> $NEW"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged: $NEW"
+          fi
+
+      - name: Create and push tag
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git tag ${{ steps.version.outputs.tag }}
+          git push origin ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Summary
- Adds workflow that watches for `package.json` version changes on main
- Automatically creates and pushes a `v*` git tag, which chains into the existing publish workflow
- No more manual `git tag` + `git push origin v*` after merging version bumps

## Flow after this
1. Merge a PR that bumps `package.json` version
2. Auto-tag workflow detects the change, pushes `v0.1.4` tag
3. Publish workflow triggers on the tag, runs tests, publishes to npm

## Test plan
- [x] Workflow syntax is valid
- Will verify end-to-end when the version bump PR (#10) merges after this