### PR TITLE
Add prefer-guard-clauses and no-type-assertion rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (31 total)
+## Available Rules (33 total)
 
 ### Expo Router Rules
 
@@ -157,6 +157,13 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | `no-require-statements`      | error    | Use ES imports, not CommonJS require                          |
 | `no-response-json-lowercase` | warning  | Use Response.json() instead of new Response(JSON.stringify()) |
 | `sql-no-nested-calls`        | error    | Don't nest sql template tags                                  |
+
+### Code Style Rules
+
+| Rule                   | Severity | Description                                               |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
+| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
 
 ### General Rules
 
@@ -378,6 +385,41 @@ sql`UPDATE users SET ${sql`name = ${name}`} WHERE id = ${id}`;
 sql`UPDATE users SET name = ${name} WHERE id = ${id}`;
 ```
 
+### `prefer-guard-clauses`
+
+```typescript
+// Bad - entire function body wrapped in if
+function handleClick(user) {
+  if (user) {
+    doSomething();
+    doMore();
+  }
+}
+
+// Good - early return
+function handleClick(user) {
+  if (!user) return;
+  doSomething();
+  doMore();
+}
+```
+
+### `no-type-assertion`
+
+```typescript
+// Bad - type casting
+const value = data as string;
+const user = response.data as User;
+
+// Good - type narrowing
+if (typeof data === 'string') {
+  const value = data;
+}
+
+// Good - proper typing
+const user: User = response.data;
+```
+
 ---
 
 ## Adding a New Rule
@@ -444,7 +486,7 @@ Returns an array of all available rule names.
 
 ```bash
 npm install     # Install dependencies
-npm test        # Run tests (213 tests)
+npm test        # Run tests
 npm run build   # Build TypeScript
 npm run lint    # ESLint + Prettier
 npm run knip    # Dead code detection

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -30,6 +30,8 @@ import { transitionProgressRange } from './transition-progress-range';
 import { transitionGestureScrollview } from './transition-gesture-scrollview';
 import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
+import { preferGuardClauses } from './prefer-guard-clauses';
+import { noTypeAssertion } from './no-type-assertion';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -63,4 +65,6 @@ export const rules: Record<string, RuleFunction> = {
   'transition-gesture-scrollview': transitionGestureScrollview,
   'transition-shared-tag-mismatch': transitionSharedTagMismatch,
   'transition-prefer-blank-stack': transitionPreferBlankStack,
+  'prefer-guard-clauses': preferGuardClauses,
+  'no-type-assertion': noTypeAssertion,
 };

--- a/src/rules/no-type-assertion.ts
+++ b/src/rules/no-type-assertion.ts
@@ -1,0 +1,37 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-type-assertion';
+
+export function noTypeAssertion(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TSAsExpression(path) {
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message:
+          'Avoid type assertions with "as". Use type narrowing, type guards, or proper typing instead',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+
+    TSTypeAssertion(path) {
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message:
+          'Avoid angle-bracket type assertions. Use type narrowing, type guards, or proper typing instead',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/src/rules/prefer-guard-clauses.ts
+++ b/src/rules/prefer-guard-clauses.ts
@@ -1,0 +1,71 @@
+import traverse from '@babel/traverse';
+import type { File, Statement } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'prefer-guard-clauses';
+
+function bodyStatements(node: any): Statement[] | null {
+  if (node.body?.type === 'BlockStatement') {
+    return node.body.body as Statement[];
+  }
+  return null;
+}
+
+export function preferGuardClauses(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(path) {
+      const statements = bodyStatements(path.node);
+      if (!statements || statements.length === 0) return;
+
+      // Case 1: Function body is a single if statement wrapping all logic
+      if (
+        statements.length === 1 &&
+        statements[0].type === 'IfStatement' &&
+        !statements[0].alternate
+      ) {
+        const ifStmt = statements[0];
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Invert this condition and return early instead of wrapping the entire function body in an if statement',
+          line: ifStmt.loc?.start.line ?? 0,
+          column: ifStmt.loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+        return;
+      }
+
+      // Case 2: Nested if statements without else (arrow pattern)
+      for (const stmt of statements) {
+        if (stmt.type !== 'IfStatement') continue;
+        checkNestedIfs(stmt, 1, results);
+      }
+    },
+  });
+
+  return results;
+}
+
+function checkNestedIfs(node: any, depth: number, results: LintResult[]): void {
+  if (node.type !== 'IfStatement') return;
+  if (node.alternate) return;
+
+  const consequent = node.consequent;
+  const body = consequent.type === 'BlockStatement' ? consequent.body : [consequent];
+
+  if (body.length === 1 && body[0].type === 'IfStatement' && !body[0].alternate) {
+    if (depth >= 1) {
+      results.push({
+        rule: RULE_NAME,
+        message: 'Use guard clauses (early returns) instead of nesting if statements',
+        line: body[0].loc?.start.line ?? 0,
+        column: body[0].loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+      return;
+    }
+    checkNestedIfs(body[0], depth + 1, results);
+  }
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(31);
+      expect(ruleNames.length).toBe(33);
     });
   });
 });

--- a/tests/no-type-assertion.test.ts
+++ b/tests/no-type-assertion.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-type-assertion'] };
+
+describe('no-type-assertion rule', () => {
+  describe('as expressions', () => {
+    it('should detect simple as assertion', () => {
+      const code = `const x = value as string;`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].rule).toBe('no-type-assertion');
+      expect(results[0].message).toContain('as');
+      expect(results[0].severity).toBe('warning');
+    });
+
+    it('should detect as assertion with complex types', () => {
+      const code = `const user = response.data as User;`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
+    it('should detect as unknown as Type pattern', () => {
+      const code = `const x = value as unknown as SpecificType;`;
+      const results = lintJsxCode(code, config);
+      // Two as expressions
+      expect(results).toHaveLength(2);
+    });
+
+    it('should detect as const', () => {
+      const code = `const colors = ['red', 'blue'] as const;`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
+    it('should detect as in function arguments', () => {
+      const code = `doSomething(event.target as HTMLInputElement);`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('angle-bracket assertions', () => {
+    it('should not encounter angle-bracket assertions in TSX', () => {
+      // Angle-bracket syntax (<Type>value) is invalid in TSX files
+      // because the parser treats <Type> as JSX. Since laint parses
+      // as TSX, this syntax is already a parse error — no rule needed.
+      // This test documents that behavior.
+      const code = `const x: string = getValue();`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('should not flag', () => {
+    it('should not flag properly typed variables', () => {
+      const code = `const x: string = getValue();`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag type annotations', () => {
+      const code = `function greet(name: string): string { return name; }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag generic type parameters', () => {
+      const code = `const items = useState<string[]>([]);`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag satisfies', () => {
+      const code = `const config = { port: 3000 } satisfies Config;`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('multiple assertions', () => {
+    it('should report each assertion separately', () => {
+      const code = `
+        const a = x as string;
+        const b = y as number;
+        const c = z as boolean;
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(3);
+    });
+  });
+});

--- a/tests/prefer-guard-clauses.test.ts
+++ b/tests/prefer-guard-clauses.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['prefer-guard-clauses'] };
+
+describe('prefer-guard-clauses rule', () => {
+  describe('single if wrapping entire function body', () => {
+    it('should detect function body wrapped in a single if', () => {
+      const code = `
+        function handleClick(user) {
+          if (user) {
+            doSomething();
+            doMore();
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].rule).toBe('prefer-guard-clauses');
+      expect(results[0].message).toContain('Invert this condition');
+      expect(results[0].severity).toBe('warning');
+    });
+
+    it('should detect arrow function body wrapped in a single if', () => {
+      const code = `
+        const handleClick = (user) => {
+          if (user) {
+            doSomething();
+          }
+        };
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
+    it('should not flag if there is an else branch', () => {
+      const code = `
+        function handleClick(user) {
+          if (user) {
+            doSomething();
+          } else {
+            doOther();
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag if there are multiple statements', () => {
+      const code = `
+        function handleClick(user) {
+          const name = user.name;
+          if (name) {
+            doSomething();
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('nested if statements (arrow pattern)', () => {
+    it('should detect nested ifs without else', () => {
+      const code = `
+        function process(data) {
+          const x = 1;
+          if (data) {
+            if (data.valid) {
+              handle(data);
+            }
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].message).toContain('guard clauses');
+    });
+
+    it('should detect deeply nested ifs', () => {
+      const code = `
+        function process(a) {
+          if (a) {
+            if (a.b) {
+              doSomething();
+            }
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      // The outer if wrapping the body triggers case 1,
+      // so we get one violation
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not flag flat if statements', () => {
+      const code = `
+        function process(data) {
+          if (!data) return;
+          if (!data.valid) return;
+          handle(data);
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag single-level if in multi-statement body', () => {
+      const code = `
+        function process(data) {
+          setup();
+          if (data) {
+            handle(data);
+          }
+          cleanup();
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty function bodies', () => {
+      const code = `function noop() {}`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should handle arrow functions without block body', () => {
+      const code = `const fn = (x) => x + 1;`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **`prefer-guard-clauses`** (warning) — flags functions where the body is wrapped in a single `if` or where `if` statements are needlessly nested (arrow pattern). Suggests early returns instead.
- **`no-type-assertion`** (warning) — flags `as` type casts. Suggests type narrowing, type guards, or proper typing instead.

Total rules: 33.

## Test plan
- [x] 234/234 tests pass (10 new tests for guard clauses, 11 for type assertions)
- [x] `npm run lint` — 0 errors
- [x] `npm run knip` — clean
- [x] README updated with rule docs and examples