### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laint",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "AI Agent Lint Rules SDK - programmatic JSX/TSX linting for AI code generation",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump to 0.1.5 to publish the two new lint rules (`prefer-guard-clauses`, `no-type-assertion`) added in #12
- Auto-tag workflow will handle tagging and publish on merge