### PR TITLE
Auto-generate GitHub release notes on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: write
       id-token: write
 
     steps:
@@ -33,3 +34,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+
+      - name: Create GitHub release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- After successful npm publish, creates a GitHub release with auto-generated notes from merged PR titles since the last tag
- Only runs after publish succeeds, so no orphaned releases for failed publishes

## Flow
1. Version bump PR merges → auto-tag creates `v0.1.5`
2. Publish workflow triggers → builds, tests, publishes to npm
3. **New:** `gh release create v0.1.5 --generate-notes` creates the GitHub release

## Test plan
- [x] Workflow syntax valid
- Will verify end-to-end on next version bump