### PR TITLE
Address review feedback on lint rules

### DIFF
--- a/src/rules/no-type-assertion.ts
+++ b/src/rules/no-type-assertion.ts
@@ -9,6 +9,14 @@ export function noTypeAssertion(ast: File, _code: string): LintResult[] {
 
   traverse(ast, {
     TSAsExpression(path) {
+      // Skip "as const" — it's idiomatic TypeScript for readonly literals
+      if (path.node.typeAnnotation.type === 'TSTypeReference') {
+        const typeName = path.node.typeAnnotation.typeName;
+        if (typeName.type === 'Identifier' && typeName.name === 'const') {
+          return;
+        }
+      }
+
       const { loc } = path.node;
       results.push({
         rule: RULE_NAME,

--- a/src/rules/prefer-guard-clauses.ts
+++ b/src/rules/prefer-guard-clauses.ts
@@ -1,12 +1,16 @@
 import traverse from '@babel/traverse';
-import type { File, Statement } from '@babel/types';
+import type { File, IfStatement, Statement } from '@babel/types';
 import type { LintResult } from '../types';
 
 const RULE_NAME = 'prefer-guard-clauses';
 
-function bodyStatements(node: any): Statement[] | null {
+interface FunctionNode {
+  body?: { type: string; body?: Statement[] };
+}
+
+function bodyStatements(node: FunctionNode): Statement[] | null {
   if (node.body?.type === 'BlockStatement') {
-    return node.body.body as Statement[];
+    return (node.body.body ?? null) as Statement[] | null;
   }
   return null;
 }
@@ -16,14 +20,14 @@ export function preferGuardClauses(ast: File, _code: string): LintResult[] {
 
   traverse(ast, {
     'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(path) {
-      const statements = bodyStatements(path.node);
+      const statements = bodyStatements(path.node as FunctionNode);
       if (!statements || statements.length === 0) return;
 
       // Case 1: Function body is a single if statement wrapping all logic
       if (
         statements.length === 1 &&
         statements[0].type === 'IfStatement' &&
-        !statements[0].alternate
+        !(statements[0] as IfStatement).alternate
       ) {
         const ifStmt = statements[0];
         results.push({
@@ -40,7 +44,7 @@ export function preferGuardClauses(ast: File, _code: string): LintResult[] {
       // Case 2: Nested if statements without else (arrow pattern)
       for (const stmt of statements) {
         if (stmt.type !== 'IfStatement') continue;
-        checkNestedIfs(stmt, 1, results);
+        checkNestedIfs(stmt as IfStatement, results);
       }
     },
   });
@@ -48,24 +52,20 @@ export function preferGuardClauses(ast: File, _code: string): LintResult[] {
   return results;
 }
 
-function checkNestedIfs(node: any, depth: number, results: LintResult[]): void {
-  if (node.type !== 'IfStatement') return;
+function checkNestedIfs(node: IfStatement, results: LintResult[]): void {
   if (node.alternate) return;
 
   const consequent = node.consequent;
-  const body = consequent.type === 'BlockStatement' ? consequent.body : [consequent];
+  const body: Statement[] =
+    consequent.type === 'BlockStatement' ? (consequent.body as Statement[]) : [consequent];
 
-  if (body.length === 1 && body[0].type === 'IfStatement' && !body[0].alternate) {
-    if (depth >= 1) {
-      results.push({
-        rule: RULE_NAME,
-        message: 'Use guard clauses (early returns) instead of nesting if statements',
-        line: body[0].loc?.start.line ?? 0,
-        column: body[0].loc?.start.column ?? 0,
-        severity: 'warning',
-      });
-      return;
-    }
-    checkNestedIfs(body[0], depth + 1, results);
+  if (body.length === 1 && body[0].type === 'IfStatement' && !(body[0] as IfStatement).alternate) {
+    results.push({
+      rule: RULE_NAME,
+      message: 'Use guard clauses (early returns) instead of nesting if statements',
+      line: body[0].loc?.start.line ?? 0,
+      column: body[0].loc?.start.column ?? 0,
+      severity: 'warning',
+    });
   }
 }

--- a/src/rules/prefer-guard-clauses.ts
+++ b/src/rules/prefer-guard-clauses.ts
@@ -1,51 +1,62 @@
 import traverse from '@babel/traverse';
-import type { File, IfStatement, Statement } from '@babel/types';
+import type {
+  ArrowFunctionExpression,
+  File,
+  FunctionDeclaration,
+  FunctionExpression,
+  IfStatement,
+  Statement,
+} from '@babel/types';
 import type { LintResult } from '../types';
 
 const RULE_NAME = 'prefer-guard-clauses';
 
-interface FunctionNode {
-  body?: { type: string; body?: Statement[] };
-}
+type FunctionNode = ArrowFunctionExpression | FunctionDeclaration | FunctionExpression;
 
 function bodyStatements(node: FunctionNode): Statement[] | null {
-  if (node.body?.type === 'BlockStatement') {
-    return node.body.body ?? null;
+  if (node.body.type === 'BlockStatement') {
+    return node.body.body;
   }
   return null;
+}
+
+function checkFunctionBody(node: FunctionNode, results: LintResult[]): void {
+  const statements = bodyStatements(node);
+  if (!statements || statements.length === 0) return;
+
+  // Case 1: Function body is a single if statement wrapping all logic
+  if (statements.length === 1 && statements[0].type === 'IfStatement' && !statements[0].alternate) {
+    const ifStmt = statements[0];
+    results.push({
+      rule: RULE_NAME,
+      message:
+        'Invert this condition and return early instead of wrapping the entire function body in an if statement',
+      line: ifStmt.loc?.start.line ?? 0,
+      column: ifStmt.loc?.start.column ?? 0,
+      severity: 'warning',
+    });
+    return;
+  }
+
+  // Case 2: Nested if statements without else (arrow pattern)
+  for (const stmt of statements) {
+    if (stmt.type !== 'IfStatement') continue;
+    checkNestedIfs(stmt, results);
+  }
 }
 
 export function preferGuardClauses(ast: File, _code: string): LintResult[] {
   const results: LintResult[] = [];
 
   traverse(ast, {
-    'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(path) {
-      const statements = bodyStatements(path.node as FunctionNode);
-      if (!statements || statements.length === 0) return;
-
-      // Case 1: Function body is a single if statement wrapping all logic
-      if (
-        statements.length === 1 &&
-        statements[0].type === 'IfStatement' &&
-        !statements[0].alternate
-      ) {
-        const ifStmt = statements[0];
-        results.push({
-          rule: RULE_NAME,
-          message:
-            'Invert this condition and return early instead of wrapping the entire function body in an if statement',
-          line: ifStmt.loc?.start.line ?? 0,
-          column: ifStmt.loc?.start.column ?? 0,
-          severity: 'warning',
-        });
-        return;
-      }
-
-      // Case 2: Nested if statements without else (arrow pattern)
-      for (const stmt of statements) {
-        if (stmt.type !== 'IfStatement') continue;
-        checkNestedIfs(stmt, results);
-      }
+    FunctionDeclaration(path) {
+      checkFunctionBody(path.node, results);
+    },
+    FunctionExpression(path) {
+      checkFunctionBody(path.node, results);
+    },
+    ArrowFunctionExpression(path) {
+      checkFunctionBody(path.node, results);
     },
   });
 

--- a/src/rules/prefer-guard-clauses.ts
+++ b/src/rules/prefer-guard-clauses.ts
@@ -10,7 +10,7 @@ interface FunctionNode {
 
 function bodyStatements(node: FunctionNode): Statement[] | null {
   if (node.body?.type === 'BlockStatement') {
-    return (node.body.body ?? null) as Statement[] | null;
+    return node.body.body ?? null;
   }
   return null;
 }
@@ -27,7 +27,7 @@ export function preferGuardClauses(ast: File, _code: string): LintResult[] {
       if (
         statements.length === 1 &&
         statements[0].type === 'IfStatement' &&
-        !(statements[0] as IfStatement).alternate
+        !statements[0].alternate
       ) {
         const ifStmt = statements[0];
         results.push({
@@ -44,7 +44,7 @@ export function preferGuardClauses(ast: File, _code: string): LintResult[] {
       // Case 2: Nested if statements without else (arrow pattern)
       for (const stmt of statements) {
         if (stmt.type !== 'IfStatement') continue;
-        checkNestedIfs(stmt as IfStatement, results);
+        checkNestedIfs(stmt, results);
       }
     },
   });
@@ -56,10 +56,9 @@ function checkNestedIfs(node: IfStatement, results: LintResult[]): void {
   if (node.alternate) return;
 
   const consequent = node.consequent;
-  const body: Statement[] =
-    consequent.type === 'BlockStatement' ? (consequent.body as Statement[]) : [consequent];
+  const body: Statement[] = consequent.type === 'BlockStatement' ? consequent.body : [consequent];
 
-  if (body.length === 1 && body[0].type === 'IfStatement' && !(body[0] as IfStatement).alternate) {
+  if (body.length === 1 && body[0].type === 'IfStatement' && !body[0].alternate) {
     results.push({
       rule: RULE_NAME,
       message: 'Use guard clauses (early returns) instead of nesting if statements',

--- a/tests/no-type-assertion.test.ts
+++ b/tests/no-type-assertion.test.ts
@@ -27,10 +27,10 @@ describe('no-type-assertion rule', () => {
       expect(results).toHaveLength(2);
     });
 
-    it('should detect as const', () => {
+    it('should not flag as const', () => {
       const code = `const colors = ['red', 'blue'] as const;`;
       const results = lintJsxCode(code, config);
-      expect(results).toHaveLength(1);
+      expect(results).toHaveLength(0);
     });
 
     it('should detect as in function arguments', () => {


### PR DESCRIPTION
## Summary
Follow-up to #12 — the review fixes didn't make it into the branch before merge.

- Skip `as const` in no-type-assertion (idiomatic, not a real cast)
- Replace `any` with structural `FunctionNode` interface and `IfStatement` type
- Remove dead recursive call in `checkNestedIfs`

## Test plan
- [x] 234/234 tests pass
- [x] Build clean