### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "laint",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "laint",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laint",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "AI Agent Lint Rules SDK - programmatic JSX/TSX linting for AI code generation",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.6 to publish review feedback fixes from #15:
  - Skip `as const` in `no-type-assertion` rule
  - Use proper Babel types instead of `any`/custom interfaces in `prefer-guard-clauses`
  - Remove dead recursive call in `checkNestedIfs`
  - Remove unnecessary type assertions

## Test plan
- All 234 tests pass
- Auto-tag workflow will create `v0.1.6` tag on merge, triggering publish to npm