### PR TITLE
Add no-manual-retry-loop lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 | Rule                   | Severity | Description                                               |
 | ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
-| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `prefer-guard-clauses`  | warning  | Use early returns instead of nesting if statements              |
+| `no-type-assertion`     | warning  | Avoid `as` type casts; use type narrowing or proper types       |
+| `no-manual-retry-loop`  | warning  | Use a retry library instead of manual retry/polling loops       |
 
 ### General Rules
 
@@ -418,6 +419,28 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-manual-retry-loop`
+
+```typescript
+// Bad - manual retry loop with setTimeout
+for (let attempt = 0; attempt < 15; attempt++) {
+  const result = await checkStatus(id);
+  if (result.ready) return result;
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+}
+
+// Good - use a retry library
+import retry from 'async-retry';
+const result = await retry(
+  async () => {
+    const res = await checkStatus(id);
+    if (!res.ready) throw new Error('not ready');
+    return res;
+  },
+  { retries: 15, minTimeout: 2000 }
+);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 | Rule                   | Severity | Description                                               |
 | ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses`  | warning  | Use early returns instead of nesting if statements              |
-| `no-type-assertion`     | warning  | Avoid `as` type casts; use type narrowing or proper types       |
-| `no-manual-retry-loop`  | warning  | Use a retry library instead of manual retry/polling loops       |
+| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
+| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-manual-retry-loop` | warning  | Use a retry library instead of manual retry/polling loops |
 
 ### General Rules
 
@@ -439,7 +439,7 @@ const result = await retry(
     if (!res.ready) throw new Error('not ready');
     return res;
   },
-  { retries: 15, minTimeout: 2000 }
+  { retries: 15, minTimeout: 2000 },
 );
 ```
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noManualRetryLoop } from './no-manual-retry-loop';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-manual-retry-loop': noManualRetryLoop,
 };

--- a/src/rules/no-manual-retry-loop.ts
+++ b/src/rules/no-manual-retry-loop.ts
@@ -1,0 +1,39 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-manual-retry-loop';
+
+export function noManualRetryLoop(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    'ForStatement|WhileStatement|DoWhileStatement'(loopPath) {
+      let hasSetTimeout = false;
+
+      loopPath.traverse({
+        CallExpression(innerPath) {
+          const callee = innerPath.node.callee;
+          if (callee.type === 'Identifier' && callee.name === 'setTimeout') {
+            hasSetTimeout = true;
+            innerPath.stop();
+          }
+        },
+      });
+
+      if (hasSetTimeout) {
+        const { loc } = loopPath.node;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Avoid manual retry/polling loops with setTimeout. Use a retry library (e.g. async-retry, p-retry) for better backoff, jitter, and error handling',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-manual-retry-loop.ts
+++ b/src/rules/no-manual-retry-loop.ts
@@ -14,7 +14,12 @@ export function noManualRetryLoop(ast: File, _code: string): LintResult[] {
       loopPath.traverse({
         CallExpression(innerPath) {
           const callee = innerPath.node.callee;
-          if (callee.type === 'Identifier' && callee.name === 'setTimeout') {
+          if (
+            (callee.type === 'Identifier' && callee.name === 'setTimeout') ||
+            (callee.type === 'MemberExpression' &&
+              callee.property.type === 'Identifier' &&
+              callee.property.name === 'setTimeout')
+          ) {
             hasSetTimeout = true;
             innerPath.stop();
           }

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-manual-retry-loop.test.ts
+++ b/tests/no-manual-retry-loop.test.ts
@@ -54,6 +54,18 @@ describe('no-manual-retry-loop rule', () => {
       expect(results).toHaveLength(1);
     });
 
+    it('should detect window.setTimeout in loop', () => {
+      const code = `
+        async function waitLoop() {
+          for (let i = 0; i < 5; i++) {
+            await new Promise(r => window.setTimeout(r, 1000));
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
     it('should detect bare setTimeout in loop', () => {
       const code = `
         async function waitLoop() {

--- a/tests/no-manual-retry-loop.test.ts
+++ b/tests/no-manual-retry-loop.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-manual-retry-loop'] };
+
+describe('no-manual-retry-loop rule', () => {
+  describe('should flag', () => {
+    it('should detect for loop with setTimeout polling', () => {
+      const code = `
+        async function waitForReady(id) {
+          for (let attempt = 0; attempt < 15; attempt++) {
+            const result = await checkStatus(id);
+            if (result.ready) return result;
+            await new Promise(resolve => setTimeout(resolve, 2000));
+          }
+          return null;
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].rule).toBe('no-manual-retry-loop');
+      expect(results[0].severity).toBe('warning');
+    });
+
+    it('should detect while loop with setTimeout retry', () => {
+      const code = `
+        async function retryFetch(url) {
+          let attempts = 0;
+          while (attempts < 3) {
+            try {
+              return await fetch(url);
+            } catch (e) {
+              attempts++;
+              await new Promise(r => setTimeout(r, 1000));
+            }
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
+    it('should detect do-while loop with setTimeout', () => {
+      const code = `
+        async function poll() {
+          let ready = false;
+          do {
+            ready = await check();
+            if (!ready) await new Promise(r => setTimeout(r, 500));
+          } while (!ready);
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+
+    it('should detect bare setTimeout in loop', () => {
+      const code = `
+        async function waitLoop() {
+          for (let i = 0; i < 5; i++) {
+            setTimeout(() => ping(), 1000);
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('should not flag', () => {
+    it('should not flag loop without setTimeout', () => {
+      const code = `
+        function sum(items) {
+          let total = 0;
+          for (const item of items) {
+            total += item.value;
+          }
+          return total;
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag async loop without setTimeout', () => {
+      const code = `
+        async function processAll(items) {
+          for (const item of items) {
+            await process(item);
+          }
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag setTimeout outside a loop', () => {
+      const code = `
+        function debounce() {
+          setTimeout(() => doWork(), 300);
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag setInterval (not in a loop)', () => {
+      const code = `
+        function startPolling() {
+          setInterval(() => check(), 5000);
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag retry library usage', () => {
+      const code = `
+        import retry from 'async-retry';
+        async function fetchWithRetry(url) {
+          return await retry(async () => {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error('failed');
+            return res.json();
+          }, { retries: 3 });
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New rule: `no-manual-retry-loop` — flags loops (for/while/do-while) containing `setTimeout`, which indicates a manual retry or polling pattern
- Suggests using a retry library (async-retry, p-retry) for proper backoff, jitter, and error handling
- Inspired by [this PR comment](https://github.com/Create-Inc/escher/pull/12173#discussion_r2801295407)

### What it flags
```typescript
// Manual polling loop
for (let attempt = 0; attempt < 15; attempt++) {
  const result = await checkStatus(id);
  if (result.ready) return result;
  await new Promise(resolve => setTimeout(resolve, 2000));
}
```

### What it doesn't flag
- Loops without setTimeout (normal iteration)
- setTimeout outside a loop (debounce, delayed execution)
- setInterval (different pattern)
- Retry library usage (async-retry, p-retry)

## Test plan
- 9 tests covering flag/no-flag cases (for, while, do-while, bare setTimeout, normal loops, retry lib)
- README documented
- 243 total tests passing