### PR TITLE
Add no-optional-props lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-optional-props`    | warning  | Use `prop: T \| null` instead of `prop?: T` in interfaces |
 
 ### General Rules
 
@@ -421,6 +422,22 @@ const user: User = response.data;
 ```
 
 ---
+
+### `no-optional-props`
+
+```typescript
+// Bad - optional properties create implicit undefined
+interface UserProps {
+  name?: string;
+  age?: number;
+}
+
+// Good - explicit null union
+interface UserProps {
+  name: string | null;
+  age: number | null;
+}
+```
 
 ## Adding a New Rule
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noOptionalProps } from './no-optional-props';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-optional-props': noOptionalProps,
 };

--- a/src/rules/no-optional-props.ts
+++ b/src/rules/no-optional-props.ts
@@ -1,0 +1,27 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-optional-props';
+
+export function noOptionalProps(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TSPropertySignature(path) {
+      if (path.node.optional) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Avoid optional properties (?:). Use an explicit union with null instead (e.g. prop: string | null)',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-optional-props.test.ts
+++ b/tests/no-optional-props.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-optional-props'] };
+
+describe('no-optional-props rule', () => {
+  describe('should flag optional properties', () => {
+    it('should flag optional property in interface', () => {
+      const code = `interface Foo { bar?: string }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].rule).toBe('no-optional-props');
+      expect(results[0].message).toContain('optional properties');
+      expect(results[0].severity).toBe('warning');
+    });
+
+    it('should flag optional property in type alias', () => {
+      const code = `type Foo = { bar?: number }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(1);
+      expect(results[0].rule).toBe('no-optional-props');
+    });
+
+    it('should flag multiple optional properties', () => {
+      const code = `
+        interface Foo {
+          bar?: string;
+          baz?: number;
+          qux?: boolean;
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(3);
+    });
+  });
+
+  describe('should not flag', () => {
+    it('should not flag required properties in interface', () => {
+      const code = `interface Foo { bar: string }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag properties with null union', () => {
+      const code = `interface Foo { bar: string | null }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag required properties', () => {
+      const code = `
+        interface Foo {
+          bar: string;
+          baz: number;
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag optional function parameters', () => {
+      const code = `function foo(bar?: string) { return bar; }`;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should not flag optional class properties', () => {
+      const code = `
+        class Foo {
+          bar?: string;
+        }
+      `;
+      const results = lintJsxCode(code, config);
+      expect(results).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Flags optional properties (`?:`) in interfaces/types
- Suggests using explicit `| null` union instead
- Aligns with CLAUDE.md: avoid optional props, use null union

## Test plan
- Tests covering interfaces, types, and negative cases
- All tests passing