### PR TITLE
Add logger-error-with-err lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -160,10 +160,11 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 ### Code Style Rules
 
-| Rule                   | Severity | Description                                               |
-| ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
-| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| Rule                    | Severity | Description                                                 |
+| ----------------------- | -------- | ----------------------------------------------------------- |
+| `prefer-guard-clauses`  | warning  | Use early returns instead of nesting if statements          |
+| `no-type-assertion`     | warning  | Avoid `as` type casts; use type narrowing or proper types   |
+| `logger-error-with-err` | warning  | logger.error() must include { err: Error } for stack traces |
 
 ### General Rules
 
@@ -418,6 +419,19 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `logger-error-with-err`
+
+```typescript
+// Bad - missing err property
+logger.error({}, 'something failed');
+logger.error({ userId: 1 }, 'request failed');
+logger.error('something went wrong');
+
+// Good - includes err for stack traces
+logger.error({ err: error }, 'something failed');
+logger.error({ err: new Error('x'), userId: 1 }, 'request failed');
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { loggerErrorWithErr } from './logger-error-with-err';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'logger-error-with-err': loggerErrorWithErr,
 };

--- a/src/rules/logger-error-with-err.ts
+++ b/src/rules/logger-error-with-err.ts
@@ -1,0 +1,92 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'logger-error-with-err';
+
+export function loggerErrorWithErr(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CallExpression(path) {
+      const { callee, loc } = path.node;
+
+      if (callee.type !== 'MemberExpression') return;
+
+      const { object, property } = callee;
+
+      // Only check calls to .error()
+      if (property.type !== 'Identifier' || property.name !== 'error') return;
+
+      // Determine the object name
+      let objectName: string | null = null;
+      if (object.type === 'Identifier') {
+        objectName = object.name;
+      }
+
+      if (!objectName) return;
+
+      // Skip console.error — different convention
+      if (objectName === 'console') return;
+
+      // Only check logger.error() and log.error()
+      if (objectName !== 'logger' && objectName !== 'log') return;
+
+      const args = path.node.arguments;
+
+      // Check if the first argument is an ObjectExpression with an `err` property
+      if (args.length === 0) {
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'logger.error() should include an { err: <Error> } property in the first argument for proper stack traces in monitoring',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+        return;
+      }
+
+      const firstArg = args[0];
+
+      if (firstArg.type !== 'ObjectExpression') {
+        // First arg is not an object — flag it
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'logger.error() should include an { err: <Error> } property in the first argument for proper stack traces in monitoring',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+        return;
+      }
+
+      // First arg is an object — check if it has an `err` key
+      const hasErrProperty = firstArg.properties.some((prop) => {
+        if (prop.type === 'ObjectProperty') {
+          if (prop.key.type === 'Identifier' && prop.key.name === 'err') {
+            return true;
+          }
+          if (prop.key.type === 'StringLiteral' && prop.key.value === 'err') {
+            return true;
+          }
+        }
+        return false;
+      });
+
+      if (!hasErrProperty) {
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'logger.error() should include an { err: <Error> } property in the first argument for proper stack traces in monitoring',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/logger-error-with-err.test.ts
+++ b/tests/logger-error-with-err.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['logger-error-with-err'] };
+
+describe('logger-error-with-err rule', () => {
+  it('should flag logger.error with empty object (no err key)', () => {
+    const code = `logger.error({}, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('logger-error-with-err');
+    expect(results[0].severity).toBe('warning');
+    expect(results[0].message).toContain('{ err: <Error> }');
+  });
+
+  it('should flag logger.error with object missing err key', () => {
+    const code = `logger.error({ userId: 1 }, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('logger-error-with-err');
+  });
+
+  it('should flag logger.error with string only (no object)', () => {
+    const code = `logger.error("msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('logger-error-with-err');
+  });
+
+  it('should flag log.error with object missing err key', () => {
+    const code = `log.error({ code: 500 }, "failed");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('logger-error-with-err');
+  });
+
+  it('should not flag logger.error with err property', () => {
+    const code = `logger.error({ err: error }, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag logger.error with err and other properties', () => {
+    const code = `logger.error({ err: new Error("x"), userId: 1 }, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag console.error (different pattern)', () => {
+    const code = `console.error("msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag logger.info (not error level)', () => {
+    const code = `logger.info({}, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag logger.warn (not error level)', () => {
+    const code = `logger.warn({}, "msg");`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Flags logger.error() calls missing { err: Error } in first argument
- Ensures proper stack traces in Sentry/monitoring
- Aligns with CLAUDE.md logging conventions

## Test plan
- Tests covering logger.error, log.error, console.error edge cases
- All tests passing