### PR TITLE
Add safe-json-parse lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (34 total)
+## Available Rules (35 total)
 
 ### Expo Router Rules
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `safe-json-parse`      | warning  | Wrap JSON.parse in try-catch to handle malformed input    |
 
 ### General Rules
 
@@ -418,6 +419,26 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+---
+
+### `safe-json-parse`
+
+```typescript
+// Bad - JSON.parse without error handling
+const data = JSON.parse(rawInput);
+
+// Good - wrapped in try-catch
+try {
+  const data = JSON.parse(rawInput);
+} catch (e) {
+  console.error('Failed to parse JSON', e);
+}
+
+// For JSON.stringify with circular references, consider using fast-safe-stringify
+// import stringify from "fast-safe-stringify";
+// const str = stringify(circularObj);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { safeJsonParse } from './safe-json-parse';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'safe-json-parse': safeJsonParse,
 };

--- a/src/rules/safe-json-parse.ts
+++ b/src/rules/safe-json-parse.ts
@@ -1,0 +1,51 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'safe-json-parse';
+
+export function safeJsonParse(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CallExpression(path) {
+      const { callee, loc } = path.node;
+
+      // Check for JSON.parse() calls
+      if (
+        callee.type !== 'MemberExpression' ||
+        callee.object.type !== 'Identifier' ||
+        callee.object.name !== 'JSON' ||
+        callee.property.type !== 'Identifier' ||
+        callee.property.name !== 'parse'
+      ) {
+        return;
+      }
+
+      // Walk up ancestors to check if inside a TryStatement
+      let isInTryCatch = false;
+      let currentPath: typeof path.parentPath = path.parentPath;
+
+      while (currentPath) {
+        if (currentPath.node.type === 'TryStatement') {
+          isInTryCatch = true;
+          break;
+        }
+        currentPath = currentPath.parentPath as typeof currentPath;
+      }
+
+      if (!isInTryCatch) {
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Wrap JSON.parse() in a try-catch block to handle malformed input. For JSON.stringify, consider using fast-safe-stringify to handle circular references',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/safe-json-parse.ts
+++ b/src/rules/safe-json-parse.ts
@@ -37,8 +37,7 @@ export function safeJsonParse(ast: File, _code: string): LintResult[] {
       if (!isInTryCatch) {
         results.push({
           rule: RULE_NAME,
-          message:
-            'Wrap JSON.parse() in a try-catch block to handle malformed input. For JSON.stringify, consider using fast-safe-stringify to handle circular references',
+          message: 'Wrap JSON.parse() in a try-catch block to handle malformed input.',
           line: loc?.start.line ?? 0,
           column: loc?.start.column ?? 0,
           severity: 'warning',

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/safe-json-parse.test.ts
+++ b/tests/safe-json-parse.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['safe-json-parse'] };
+
+describe('safe-json-parse rule', () => {
+  it('should flag bare JSON.parse(data)', () => {
+    const code = `
+      const data = JSON.parse(rawInput);
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('safe-json-parse');
+    expect(results[0].message).toContain('try-catch');
+    expect(results[0].message).toContain('fast-safe-stringify');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should flag JSON.parse in if/else but not try-catch', () => {
+    const code = `
+      function process(input) {
+        if (input) {
+          const data = JSON.parse(input);
+          return data;
+        } else {
+          return null;
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('safe-json-parse');
+  });
+
+  it('should flag JSON.parse inside a function with no try-catch', () => {
+    const code = `
+      function parseData(raw) {
+        const parsed = JSON.parse(raw);
+        return parsed;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('safe-json-parse');
+  });
+
+  it('should NOT flag JSON.parse inside try block', () => {
+    const code = `
+      function parseData(raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          return parsed;
+        } catch (e) {
+          return null;
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should NOT flag JSON.parse inside catch block', () => {
+    const code = `
+      function handle(raw) {
+        try {
+          doSomething();
+        } catch (e) {
+          const fallback = JSON.parse(raw);
+          return fallback;
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should NOT flag JSON.stringify (different concern)', () => {
+    const code = `
+      const str = JSON.stringify({ key: 'value' });
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should NOT flag JSON.parse with a wrapper function that has try-catch around the call', () => {
+    const code = `
+      function safeParse(raw) {
+        try {
+          return JSON.parse(raw);
+        } catch (e) {
+          console.error('Parse failed', e);
+          return null;
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/safe-json-parse.test.ts
+++ b/tests/safe-json-parse.test.ts
@@ -12,7 +12,6 @@ describe('safe-json-parse rule', () => {
     expect(results).toHaveLength(1);
     expect(results[0].rule).toBe('safe-json-parse');
     expect(results[0].message).toContain('try-catch');
-    expect(results[0].message).toContain('fast-safe-stringify');
     expect(results[0].severity).toBe('warning');
   });
 


### PR DESCRIPTION
## Summary
- Flags JSON.parse() calls not wrapped in try-catch
- Suggests fast-safe-stringify for JSON.stringify with circular refs

## Test plan
- Tests covering wrapped and unwrapped cases
- All tests passing