### PR TITLE
Add no-nested-try-catch lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-nested-try-catch`  | warning  | Avoid nested try-catch; flatten or use Result types       |
 
 ### General Rules
 
@@ -418,6 +419,46 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+---
+
+### `no-nested-try-catch`
+
+```typescript
+// Bad - nested try-catch blocks
+async function fetchData() {
+  try {
+    const response = await fetch(url);
+    try {
+      const data = await response.json();
+      return data;
+    } catch (parseError) {
+      console.error('Parse failed', parseError);
+    }
+  } catch (networkError) {
+    console.error('Network failed', networkError);
+  }
+}
+
+// Good - flattened with early return
+async function fetchData() {
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (networkError) {
+    console.error('Network failed', networkError);
+    return null;
+  }
+
+  try {
+    const data = await response.json();
+    return data;
+  } catch (parseError) {
+    console.error('Parse failed', parseError);
+    return null;
+  }
+}
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noNestedTryCatch } from './no-nested-try-catch';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-nested-try-catch': noNestedTryCatch,
 };

--- a/src/rules/no-nested-try-catch.ts
+++ b/src/rules/no-nested-try-catch.ts
@@ -1,0 +1,38 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-nested-try-catch';
+
+export function noNestedTryCatch(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TryStatement(path) {
+      let current: typeof path.parentPath = path.parentPath;
+      while (current) {
+        if (current.isTryStatement()) {
+          results.push({
+            rule: RULE_NAME,
+            message:
+              'Avoid nested try-catch blocks. Flatten with early returns, extract into separate functions, or use a Result type',
+            line: path.node.loc?.start.line ?? 0,
+            column: path.node.loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+          break;
+        }
+        if (
+          current.isFunctionDeclaration() ||
+          current.isFunctionExpression() ||
+          current.isArrowFunctionExpression()
+        ) {
+          break;
+        }
+        current = current.parentPath as typeof current;
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-nested-try-catch.test.ts
+++ b/tests/no-nested-try-catch.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-nested-try-catch'] };
+
+describe('no-nested-try-catch rule', () => {
+  it('should flag try-catch inside another try block', () => {
+    const code = `
+      function doWork() {
+        try {
+          try {
+            riskyOperation();
+          } catch (innerError) {
+            handleInner(innerError);
+          }
+        } catch (outerError) {
+          handleOuter(outerError);
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-nested-try-catch');
+    expect(results[0].severity).toBe('warning');
+    expect(results[0].message).toContain('Avoid nested try-catch');
+  });
+
+  it('should flag try-catch inside a catch block', () => {
+    const code = `
+      function doWork() {
+        try {
+          riskyOperation();
+        } catch (error) {
+          try {
+            recover();
+          } catch (recoverError) {
+            logError(recoverError);
+          }
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-nested-try-catch');
+    expect(results[0].message).toContain('Flatten');
+  });
+
+  it('should not flag sequential try-catch blocks', () => {
+    const code = `
+      function doWork() {
+        try {
+          firstOperation();
+        } catch (e1) {
+          handleFirst(e1);
+        }
+        try {
+          secondOperation();
+        } catch (e2) {
+          handleSecond(e2);
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag a single try-catch', () => {
+    const code = `
+      function doWork() {
+        try {
+          riskyOperation();
+        } catch (error) {
+          handleError(error);
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag try-catch in a separate function defined inside a try block', () => {
+    const code = `
+      function doWork() {
+        try {
+          const helper = () => {
+            try {
+              riskyOperation();
+            } catch (innerError) {
+              handleInner(innerError);
+            }
+          };
+          helper();
+        } catch (outerError) {
+          handleOuter(outerError);
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should flag deeply nested try-catch', () => {
+    const code = `
+      function doWork() {
+        try {
+          try {
+            try {
+              riskyOperation();
+            } catch (e3) {
+              handle3(e3);
+            }
+          } catch (e2) {
+            handle2(e2);
+          }
+        } catch (e1) {
+          handle1(e1);
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    results.forEach((r) => {
+      expect(r.rule).toBe('no-nested-try-catch');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Flags nested try-catch blocks
- Suggests flattening with early returns or Result types

## Test plan
- Tests covering nested and non-nested cases
- All tests passing