### PR TITLE
Add no-inline-styles lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-inline-styles`     | warning  | Use Tailwind classes instead of inline style prop         |
 
 ### General Rules
 
@@ -418,6 +419,20 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+---
+
+### `no-inline-styles`
+
+```jsx
+// Bad - inline style prop
+<div style={{ color: 'red' }} />
+<View style={styles.container} />
+
+// Good - use Tailwind classes
+<div className="text-red-500" />
+<View className="flex-1" />
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noInlineStyles } from './no-inline-styles';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-inline-styles': noInlineStyles,
 };

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,0 +1,42 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-inline-styles';
+
+export function noInlineStyles(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    JSXAttribute(path) {
+      const { name, loc } = path.node;
+
+      // Check if the attribute name is "style"
+      if (name.type !== 'JSXIdentifier' || name.name !== 'style') {
+        return;
+      }
+
+      // Don't flag <style> elements (HTML style tags)
+      const openingElement = path.parentPath?.parent;
+      if (
+        openingElement &&
+        openingElement.type === 'JSXOpeningElement' &&
+        openingElement.name.type === 'JSXIdentifier' &&
+        openingElement.name.name === 'style'
+      ) {
+        return;
+      }
+
+      results.push({
+        rule: RULE_NAME,
+        message:
+          'Avoid inline styles. Use Tailwind CSS classes (className) instead for consistency and maintainability',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-inline-styles.test.ts
+++ b/tests/no-inline-styles.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-inline-styles'] };
+
+describe('no-inline-styles rule', () => {
+  it('should flag inline style object on div', () => {
+    const code = `<div style={{ color: 'red' }} />`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-inline-styles');
+    expect(results[0].message).toContain('Avoid inline styles');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should flag style reference on View', () => {
+    const code = `<View style={styles.container} />`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-inline-styles');
+  });
+
+  it('should flag style array on Text', () => {
+    const code = `<Text style={[styles.a, styles.b]} />`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-inline-styles');
+  });
+
+  it('should not flag className usage', () => {
+    const code = `<div className="text-red-500" />`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag HTML style element', () => {
+    const code = `<style>{css}</style>`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag elements without style prop', () => {
+    const code = `<div className="flex" id="main" />`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Flags `style={}` JSX attributes
- Encourages Tailwind CSS classes for consistency

## Test plan
- Tests covering inline styles, Tailwind usage, style elements
- All tests passing