### PR TITLE
Add no-string-coerce-error lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -160,10 +160,11 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 ### Code Style Rules
 
-| Rule                   | Severity | Description                                               |
-| ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
-| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| Rule                     | Severity | Description                                                      |
+| ------------------------ | -------- | ---------------------------------------------------------------- |
+| `prefer-guard-clauses`   | warning  | Use early returns instead of nesting if statements               |
+| `no-type-assertion`      | warning  | Avoid `as` type casts; use type narrowing or proper types        |
+| `no-string-coerce-error` | warning  | Use JSON.stringify instead of String() for unknown caught errors |
 
 ### General Rules
 
@@ -418,6 +419,16 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-string-coerce-error`
+
+```typescript
+// Bad - String() on a non-Error object produces '[object Object]'
+const message = error instanceof Error ? error.message : String(error);
+
+// Good - JSON.stringify preserves object structure
+const message = error instanceof Error ? error.message : JSON.stringify(error);
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noStringCoerceError } from './no-string-coerce-error';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-string-coerce-error': noStringCoerceError,
 };

--- a/src/rules/no-string-coerce-error.ts
+++ b/src/rules/no-string-coerce-error.ts
@@ -1,0 +1,72 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-string-coerce-error';
+
+/**
+ * Check if an expression contains a `String(name)` call where `name` matches the given identifier.
+ */
+function containsStringCall(node: t.Node, name: string): t.CallExpression | null {
+  if (
+    t.isCallExpression(node) &&
+    t.isIdentifier(node.callee, { name: 'String' }) &&
+    node.arguments.length === 1 &&
+    t.isIdentifier(node.arguments[0], { name })
+  ) {
+    return node;
+  }
+
+  // Check children for nested String() calls (e.g. `new Error(String(err))`)
+  for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+    const child = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (t.isNode(item)) {
+          const found = containsStringCall(item, name);
+          if (found) return found;
+        }
+      }
+    } else if (t.isNode(child)) {
+      const found = containsStringCall(child, name);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+export function noStringCoerceError(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    ConditionalExpression(path) {
+      const { test, alternate } = path.node;
+
+      // Match: <ident> instanceof Error
+      if (
+        !t.isBinaryExpression(test, { operator: 'instanceof' }) ||
+        !t.isIdentifier(test.left) ||
+        !t.isIdentifier(test.right, { name: 'Error' })
+      ) {
+        return;
+      }
+
+      const errorName = test.left.name;
+      const stringCall = containsStringCall(alternate, errorName);
+
+      if (stringCall) {
+        results.push({
+          rule: RULE_NAME,
+          message: `String(${errorName}) produces '[object Object]' for non-Error objects. Use JSON.stringify(${errorName}) instead.`,
+          line: stringCall.loc?.start.line ?? path.node.loc?.start.line ?? 0,
+          column: stringCall.loc?.start.column ?? path.node.loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-string-coerce-error.ts
+++ b/src/rules/no-string-coerce-error.ts
@@ -59,7 +59,7 @@ export function noStringCoerceError(ast: File, _code: string): LintResult[] {
       if (stringCall) {
         results.push({
           rule: RULE_NAME,
-          message: `String(${errorName}) produces '[object Object]' for non-Error objects. Use JSON.stringify(${errorName}) instead.`,
+          message: `String(${errorName}) may produce '[object Object]' for non-Error objects. Consider JSON.stringify(${errorName}) to preserve structure.`,
           line: stringCall.loc?.start.line ?? path.node.loc?.start.line ?? 0,
           column: stringCall.loc?.start.column ?? path.node.loc?.start.column ?? 0,
           severity: 'warning',

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-string-coerce-error.test.ts
+++ b/tests/no-string-coerce-error.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-string-coerce-error';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags String(error) in else branch of instanceof Error ternary', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : String(error);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('JSON.stringify');
+  });
+
+  it('flags String(err) with different variable names', () => {
+    const code = `
+      const msg = err instanceof Error ? err.message : String(err);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags nested String(error) in else branch', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : new Error(String(error));
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows JSON.stringify in else branch', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : JSON.stringify(error);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows String() on unrelated ternaries', () => {
+    const code = `
+      const x = typeof value === 'number' ? value : String(value);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('ignores String() with a different variable than the instanceof check', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : String(other);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `no-string-coerce-error` lint rule that flags `String(error)` in the else branch of `error instanceof Error` ternaries
- `String()` on a non-Error object produces `'[object Object]'` — the rule suggests `JSON.stringify()` instead to preserve object structure
- Includes 6 test cases covering variable names, nested calls, and false positive avoidance

## Test plan
- [x] All 240 existing tests pass
- [x] 6 new tests for the rule cover flagging, nesting, and false positives