### PR TITLE
Add 6 new lint rules from Escher PR review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const webRules = getRulesForPlatform('web');
 const backendRules = getRulesForPlatform('backend');
 ```
 
-## Available Rules (34 total)
+## Available Rules (40 total)
 
 ### Expo Router Rules
 
@@ -175,6 +175,7 @@ const backendRules = getRulesForPlatform('backend');
 | Rule                            | Severity | Platform | Description                                            |
 | ------------------------------- | -------- | -------- | ------------------------------------------------------ |
 | `no-tailwind-animation-classes` | warning  | web      | Avoid animate-\* classes, use style jsx global instead |
+| `no-inline-styles`              | warning  | web      | Avoid inline styles, use Tailwind CSS classes instead  |
 
 ### Backend / SQL Rules
 
@@ -184,6 +185,13 @@ const backendRules = getRulesForPlatform('backend');
 | `no-response-json-lowercase` | warning  | backend  | Use Response.json() instead of new Response(JSON.stringify()) |
 | `sql-no-nested-calls`        | error    | backend  | Don't nest sql template tags                                  |
 
+### Error Handling Rules
+
+| Rule                       | Severity | Platform     | Description                                                        |
+| -------------------------- | -------- | ------------ | ------------------------------------------------------------------ |
+| `catch-must-log-to-sentry` | warning  | web, backend | Catch blocks with logger.error/console.error must also call Sentry |
+| `url-params-must-encode`   | warning  | web, backend | URL query param values must be wrapped in encodeURIComponent()     |
+
 ### Code Style Rules
 
 | Rule                     | Severity | Platform  | Description                                                      |
@@ -191,6 +199,9 @@ const backendRules = getRulesForPlatform('backend');
 | `prefer-guard-clauses`   | warning  | universal | Use early returns instead of nesting if statements               |
 | `no-type-assertion`      | warning  | universal | Avoid `as` type casts; use type narrowing or proper types        |
 | `no-string-coerce-error` | warning  | universal | Use JSON.stringify instead of String() for unknown caught errors |
+| `no-nested-try-catch`    | warning  | universal | Avoid nested try-catch blocks, extract to separate functions     |
+| `no-magic-env-strings`   | warning  | universal | Use centralized enum for env variable names, not magic strings   |
+| `no-loose-equality`      | warning  | universal | Use === and !== instead of == and != (except == null)            |
 
 ### General Rules
 
@@ -455,6 +466,97 @@ const message = error instanceof Error ? error.message : String(error);
 
 // Good - JSON.stringify preserves object structure
 const message = error instanceof Error ? error.message : JSON.stringify(error);
+```
+
+### `no-inline-styles`
+
+```tsx
+// Bad - inline style objects
+<div style={{ color: 'red', fontSize: 16 }}>Hello</div>
+
+// Good - Tailwind CSS classes
+<div className="text-red-500 text-base">Hello</div>
+```
+
+### `no-nested-try-catch`
+
+```typescript
+// Bad - nested try-catch
+try {
+  try {
+    inner();
+  } catch (e) {}
+} catch (e) {}
+
+// Good - extract to separate function
+function safeInner() {
+  try {
+    inner();
+  } catch (e) {}
+}
+try {
+  safeInner();
+} catch (e) {}
+```
+
+### `catch-must-log-to-sentry`
+
+```typescript
+// Bad - logs error but no Sentry
+try {
+  fetchData();
+} catch (error) {
+  logger.error('Failed', error);
+}
+
+// Good - both logging and Sentry
+try {
+  fetchData();
+} catch (error) {
+  logger.error('Failed', error);
+  Sentry.captureException(error);
+}
+```
+
+### `url-params-must-encode`
+
+```typescript
+// Bad - unencoded query param
+const url = `https://api.example.com?q=${query}`;
+
+// Good - encoded query param
+const url = `https://api.example.com?q=${encodeURIComponent(query)}`;
+```
+
+### `no-magic-env-strings`
+
+```typescript
+// Bad - hardcoded env string
+const key = process.env.API_KEY;
+const url = process.env['DATABASE_URL'];
+
+// Good - use centralized enum
+const key = process.env[EnvVars.API_KEY];
+```
+
+### `no-loose-equality`
+
+```typescript
+// Bad - loose equality
+if (a == b) {
+}
+if (x != 'hello') {
+}
+
+// Good - strict equality
+if (a === b) {
+}
+if (x !== 'hello') {
+}
+
+// OK - == null is idiomatic for null/undefined check
+if (value == null) {
+}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -160,10 +160,11 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 ### Code Style Rules
 
-| Rule                   | Severity | Description                                               |
-| ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
-| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| Rule                     | Severity | Description                                                      |
+| ------------------------ | -------- | ---------------------------------------------------------------- |
+| `prefer-guard-clauses`   | warning  | Use early returns instead of nesting if statements               |
+| `no-type-assertion`      | warning  | Avoid `as` type casts; use type narrowing or proper types        |
+| `no-string-coerce-error` | warning  | Use JSON.stringify instead of String() for unknown caught errors |
 
 ### General Rules
 
@@ -418,6 +419,16 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-string-coerce-error`
+
+```typescript
+// Bad - String() on a non-Error object produces '[object Object]'
+const message = error instanceof Error ? error.message : String(error);
+
+// Good - JSON.stringify preserves object structure
+const message = error instanceof Error ? error.message : JSON.stringify(error);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ By default, all 31 rules run. To customize, create a `laint.config.json` in your
 { "rules": ["no-tailwind-animation-classes", "no-stylesheet-create"], "exclude": true }
 ```
 
+```json
+// Run all rules for a platform (platform mode)
+{ "platform": "expo" }
+```
+
+**Platforms:** `expo`, `web`, `backend`. Platform mode runs all rules tagged for that platform plus universal rules (rules not specific to any platform).
+
 ### CLI
 
 ```bash
@@ -81,7 +88,7 @@ const results = lintJsxCode(code, {
   exclude: true,
 });
 
-// Run all 31 rules
+// Run all rules
 const allResults = lintJsxCode(code, {
   rules: [],
   exclude: true,
@@ -91,86 +98,105 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
+### Platform Mode
+
+Run rules by platform — includes platform-tagged rules plus universal rules:
+
+```typescript
+import { lintJsxCode, getRulesForPlatform } from 'laint';
+
+// Run all rules for Expo
+const results = lintJsxCode(code, {
+  rules: [],
+  platform: 'expo',
+});
+
+// Get rule names for a platform
+const expoRules = getRulesForPlatform('expo'); // expo-tagged + universal rules
+const webRules = getRulesForPlatform('web');
+const backendRules = getRulesForPlatform('backend');
+```
+
 ## Available Rules (34 total)
 
 ### Expo Router Rules
 
-| Rule                 | Severity | Description                                              |
-| -------------------- | -------- | -------------------------------------------------------- |
-| `no-relative-paths`  | error    | Use absolute paths in router.navigate/push and Link href |
-| `header-shown-false` | warning  | (tabs) Screen in root layout needs `headerShown: false`  |
+| Rule                 | Severity | Platform  | Description                                              |
+| -------------------- | -------- | --------- | -------------------------------------------------------- |
+| `no-relative-paths`  | error    | expo, web | Use absolute paths in router.navigate/push and Link href |
+| `header-shown-false` | warning  | expo      | (tabs) Screen in root layout needs `headerShown: false`  |
 
 ### React Native / Expo Rules
 
-| Rule                               | Severity | Description                                          |
-| ---------------------------------- | -------- | ---------------------------------------------------- |
-| `no-stylesheet-create`             | warning  | Use inline styles instead of StyleSheet.create()     |
-| `no-safeareaview`                  | warning  | Use useSafeAreaInsets() hook instead of SafeAreaView |
-| `expo-image-import`                | warning  | Import Image from expo-image, not react-native       |
-| `no-tab-bar-height`                | error    | Never set explicit height in tabBarStyle             |
-| `scrollview-horizontal-flexgrow`   | warning  | Horizontal ScrollView needs `flexGrow: 0`            |
-| `expo-font-loaded-check`           | error    | useFonts() must check loaded before rendering        |
-| `tabs-screen-options-header-shown` | warning  | Tabs screenOptions should have `headerShown: false`  |
-| `native-tabs-bottom-padding`       | warning  | NativeTabs screens need 64px bottom padding          |
-| `textinput-keyboard-avoiding`      | warning  | TextInput should be inside KeyboardAvoidingView      |
+| Rule                               | Severity | Platform | Description                                          |
+| ---------------------------------- | -------- | -------- | ---------------------------------------------------- |
+| `no-stylesheet-create`             | warning  | expo     | Use inline styles instead of StyleSheet.create()     |
+| `no-safeareaview`                  | warning  | expo     | Use useSafeAreaInsets() hook instead of SafeAreaView |
+| `expo-image-import`                | warning  | expo     | Import Image from expo-image, not react-native       |
+| `no-tab-bar-height`                | error    | expo     | Never set explicit height in tabBarStyle             |
+| `scrollview-horizontal-flexgrow`   | warning  | expo     | Horizontal ScrollView needs `flexGrow: 0`            |
+| `expo-font-loaded-check`           | error    | expo     | useFonts() must check loaded before rendering        |
+| `tabs-screen-options-header-shown` | warning  | expo     | Tabs screenOptions should have `headerShown: false`  |
+| `native-tabs-bottom-padding`       | warning  | expo     | NativeTabs screens need 64px bottom padding          |
+| `textinput-keyboard-avoiding`      | warning  | expo     | TextInput should be inside KeyboardAvoidingView      |
 
 ### Liquid Glass Rules (expo-glass-effect)
 
-| Rule                         | Severity | Description                                           |
-| ---------------------------- | -------- | ----------------------------------------------------- |
-| `no-border-width-on-glass`   | error    | No borderWidth on GlassView (breaks borderRadius)     |
-| `glass-needs-fallback`       | warning  | Check isLiquidGlassAvailable() before using GlassView |
-| `glass-interactive-prop`     | warning  | GlassView in pressables needs `isInteractive={true}`  |
-| `glass-no-opacity-animation` | warning  | No opacity animations on GlassView                    |
+| Rule                         | Severity | Platform | Description                                           |
+| ---------------------------- | -------- | -------- | ----------------------------------------------------- |
+| `no-border-width-on-glass`   | error    | expo     | No borderWidth on GlassView (breaks borderRadius)     |
+| `glass-needs-fallback`       | warning  | expo     | Check isLiquidGlassAvailable() before using GlassView |
+| `glass-interactive-prop`     | warning  | expo     | GlassView in pressables needs `isInteractive={true}`  |
+| `glass-no-opacity-animation` | warning  | expo     | No opacity animations on GlassView                    |
 
 ### React / JSX Rules
 
-| Rule                         | Severity | Description                                   |
-| ---------------------------- | -------- | --------------------------------------------- |
-| `no-class-components`        | warning  | Use function components with hooks            |
-| `no-inline-script-code`      | error    | Script tags should use template literals      |
-| `no-react-query-missing`     | warning  | Use @tanstack/react-query for data fetching   |
-| `browser-api-in-useeffect`   | warning  | window/localStorage only in useEffect for SSR |
-| `fetch-response-ok-check`    | warning  | Check response.ok when using fetch            |
-| `no-complex-jsx-expressions` | warning  | Avoid IIFEs and complex expressions in JSX    |
+| Rule                         | Severity | Platform     | Description                                   |
+| ---------------------------- | -------- | ------------ | --------------------------------------------- |
+| `no-class-components`        | warning  | expo, web    | Use function components with hooks            |
+| `no-inline-script-code`      | error    | web          | Script tags should use template literals      |
+| `no-react-query-missing`     | warning  | expo, web    | Use @tanstack/react-query for data fetching   |
+| `browser-api-in-useeffect`   | warning  | web          | window/localStorage only in useEffect for SSR |
+| `fetch-response-ok-check`    | warning  | web, backend | Check response.ok when using fetch            |
+| `no-complex-jsx-expressions` | warning  | expo, web    | Avoid IIFEs and complex expressions in JSX    |
 
 ### Screen Transitions Rules (react-native-screen-transitions)
 
-| Rule                             | Severity | Description                                                               |
-| -------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `transition-worklet-directive`   | error    | screenStyleInterpolator functions must include "worklet" directive        |
-| `transition-progress-range`      | warning  | interpolate() should cover full [0, 1, 2] range including exit phase      |
-| `transition-gesture-scrollview`  | warning  | Use Transition.ScrollView/FlatList instead of regular versions            |
-| `transition-shared-tag-mismatch` | warning  | sharedBoundTag on Transition.Pressable must have matching Transition.View |
-| `transition-prefer-blank-stack`  | warning  | Use Blank Stack instead of enableTransitions on Native Stack              |
+| Rule                             | Severity | Platform | Description                                                               |
+| -------------------------------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `transition-worklet-directive`   | error    | expo     | screenStyleInterpolator functions must include "worklet" directive        |
+| `transition-progress-range`      | warning  | expo     | interpolate() should cover full [0, 1, 2] range including exit phase      |
+| `transition-gesture-scrollview`  | warning  | expo     | Use Transition.ScrollView/FlatList instead of regular versions            |
+| `transition-shared-tag-mismatch` | warning  | expo     | sharedBoundTag on Transition.Pressable must have matching Transition.View |
+| `transition-prefer-blank-stack`  | warning  | expo     | Use Blank Stack instead of enableTransitions on Native Stack              |
 
 ### Tailwind CSS Rules
 
-| Rule                            | Severity | Description                                            |
-| ------------------------------- | -------- | ------------------------------------------------------ |
-| `no-tailwind-animation-classes` | warning  | Avoid animate-\* classes, use style jsx global instead |
+| Rule                            | Severity | Platform | Description                                            |
+| ------------------------------- | -------- | -------- | ------------------------------------------------------ |
+| `no-tailwind-animation-classes` | warning  | web      | Avoid animate-\* classes, use style jsx global instead |
 
 ### Backend / SQL Rules
 
-| Rule                         | Severity | Description                                                   |
-| ---------------------------- | -------- | ------------------------------------------------------------- |
-| `no-require-statements`      | error    | Use ES imports, not CommonJS require                          |
-| `no-response-json-lowercase` | warning  | Use Response.json() instead of new Response(JSON.stringify()) |
-| `sql-no-nested-calls`        | error    | Don't nest sql template tags                                  |
+| Rule                         | Severity | Platform | Description                                                   |
+| ---------------------------- | -------- | -------- | ------------------------------------------------------------- |
+| `no-require-statements`      | error    | backend  | Use ES imports, not CommonJS require                          |
+| `no-response-json-lowercase` | warning  | backend  | Use Response.json() instead of new Response(JSON.stringify()) |
+| `sql-no-nested-calls`        | error    | backend  | Don't nest sql template tags                                  |
 
 ### Code Style Rules
 
-| Rule                     | Severity | Description                                                      |
-| ------------------------ | -------- | ---------------------------------------------------------------- |
-| `prefer-guard-clauses`   | warning  | Use early returns instead of nesting if statements               |
-| `no-type-assertion`      | warning  | Avoid `as` type casts; use type narrowing or proper types        |
-| `no-string-coerce-error` | warning  | Use JSON.stringify instead of String() for unknown caught errors |
+| Rule                     | Severity | Platform  | Description                                                      |
+| ------------------------ | -------- | --------- | ---------------------------------------------------------------- |
+| `prefer-guard-clauses`   | warning  | universal | Use early returns instead of nesting if statements               |
+| `no-type-assertion`      | warning  | universal | Avoid `as` type casts; use type narrowing or proper types        |
+| `no-string-coerce-error` | warning  | universal | Use JSON.stringify instead of String() for unknown caught errors |
 
 ### General Rules
 
-| Rule                  | Severity | Description                                   |
-| --------------------- | -------- | --------------------------------------------- |
-| `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
+| Rule                  | Severity | Platform  | Description                                   |
+| --------------------- | -------- | --------- | --------------------------------------------- |
+| `prefer-lucide-icons` | warning  | expo, web | Prefer lucide-react/lucide-react-native icons |
 
 ---
 
@@ -476,6 +502,7 @@ export function myRule(ast: File, code: string): LintResult[] {
 - `code` - JSX/TSX source code to lint
 - `config.rules` - Array of rule names
 - `config.exclude` - (optional) When `true`, runs all rules except those in `rules`. Default: `false`
+- `config.platform` - (optional) `'expo' | 'web' | 'backend'`. When set, runs platform-tagged + universal rules. Takes precedence over `rules`/`exclude`
 
 **Returns:** Array of `LintResult`:
 
@@ -492,6 +519,12 @@ interface LintResult {
 ### `getAllRuleNames(): string[]`
 
 Returns an array of all available rule names.
+
+### `getRulesForPlatform(platform: Platform): string[]`
+
+Returns rule names for a platform (platform-tagged + universal rules).
+
+**Platforms:** `'expo' | 'web' | 'backend'`
 
 ## Development
 

--- a/src/rules/catch-must-log-to-sentry.ts
+++ b/src/rules/catch-must-log-to-sentry.ts
@@ -1,0 +1,66 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'catch-must-log-to-sentry';
+
+/**
+ * Recursively check if a node contains a call matching `object.method` pattern.
+ */
+function containsCall(node: t.Node, objectName: string, methodName: string): boolean {
+  if (
+    t.isCallExpression(node) &&
+    t.isMemberExpression(node.callee) &&
+    t.isIdentifier(node.callee.object, { name: objectName }) &&
+    t.isIdentifier(node.callee.property, { name: methodName })
+  ) {
+    return true;
+  }
+
+  for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+    const child = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (t.isNode(item) && containsCall(item, objectName, methodName)) return true;
+      }
+    } else if (t.isNode(child) && containsCall(child, objectName, methodName)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsErrorLogging(node: t.Node): boolean {
+  return containsCall(node, 'logger', 'error') || containsCall(node, 'console', 'error');
+}
+
+function containsSentryCapture(node: t.Node): boolean {
+  return containsCall(node, 'Sentry', 'captureException');
+}
+
+export function catchMustLogToSentry(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CatchClause(path) {
+      const body = path.node.body;
+
+      // Only flag if catch block has error logging but no Sentry
+      if (containsErrorLogging(body) && !containsSentryCapture(body)) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Catch block logs an error but does not call Sentry.captureException(). Add Sentry reporting.',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noStringCoerceError } from './no-string-coerce-error';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-string-coerce-error': noStringCoerceError,
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,12 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noStringCoerceError } from './no-string-coerce-error';
+import { noInlineStyles } from './no-inline-styles';
+import { catchMustLogToSentry } from './catch-must-log-to-sentry';
+import { noNestedTryCatch } from './no-nested-try-catch';
+import { urlParamsMustEncode } from './url-params-must-encode';
+import { noMagicEnvStrings } from './no-magic-env-strings';
+import { noLooseEquality } from './no-loose-equality';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +75,10 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-string-coerce-error': noStringCoerceError,
+  'no-inline-styles': noInlineStyles,
+  'catch-must-log-to-sentry': catchMustLogToSentry,
+  'no-nested-try-catch': noNestedTryCatch,
+  'url-params-must-encode': urlParamsMustEncode,
+  'no-magic-env-strings': noMagicEnvStrings,
+  'no-loose-equality': noLooseEquality,
 };

--- a/src/rules/meta.ts
+++ b/src/rules/meta.ts
@@ -30,6 +30,7 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
   'no-inline-script-code': ['web'],
   'browser-api-in-useeffect': ['web'],
   'no-tailwind-animation-classes': ['web'],
+  'no-inline-styles': ['web'],
 
   // Expo + Web (shared frontend)
   'no-relative-paths': ['expo', 'web'],
@@ -40,6 +41,8 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
 
   // Web + Backend
   'fetch-response-ok-check': ['web', 'backend'],
+  'catch-must-log-to-sentry': ['web', 'backend'],
+  'url-params-must-encode': ['web', 'backend'],
 
   // Backend only
   'no-require-statements': ['backend'],
@@ -47,5 +50,5 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
   'sql-no-nested-calls': ['backend'],
 
   // Universal rules (NOT listed here): prefer-guard-clauses, no-type-assertion,
-  // no-string-coerce-error
+  // no-string-coerce-error, no-nested-try-catch, no-magic-env-strings, no-loose-equality
 };

--- a/src/rules/meta.ts
+++ b/src/rules/meta.ts
@@ -1,0 +1,51 @@
+import type { Platform } from '../types';
+
+/**
+ * Platform tags for rules. Only platform-specific rules are listed here.
+ * Any rule NOT in this map is universal (included on all platforms).
+ */
+export const rulePlatforms: Partial<Record<string, Platform[]>> = {
+  // Expo / React Native
+  'no-stylesheet-create': ['expo'],
+  'no-safeareaview': ['expo'],
+  'no-tab-bar-height': ['expo'],
+  'no-border-width-on-glass': ['expo'],
+  'expo-image-import': ['expo'],
+  'scrollview-horizontal-flexgrow': ['expo'],
+  'glass-needs-fallback': ['expo'],
+  'glass-interactive-prop': ['expo'],
+  'header-shown-false': ['expo'],
+  'expo-font-loaded-check': ['expo'],
+  'tabs-screen-options-header-shown': ['expo'],
+  'native-tabs-bottom-padding': ['expo'],
+  'glass-no-opacity-animation': ['expo'],
+  'textinput-keyboard-avoiding': ['expo'],
+  'transition-worklet-directive': ['expo'],
+  'transition-progress-range': ['expo'],
+  'transition-gesture-scrollview': ['expo'],
+  'transition-shared-tag-mismatch': ['expo'],
+  'transition-prefer-blank-stack': ['expo'],
+
+  // Web
+  'no-inline-script-code': ['web'],
+  'browser-api-in-useeffect': ['web'],
+  'no-tailwind-animation-classes': ['web'],
+
+  // Expo + Web (shared frontend)
+  'no-relative-paths': ['expo', 'web'],
+  'no-class-components': ['expo', 'web'],
+  'no-react-query-missing': ['expo', 'web'],
+  'no-complex-jsx-expressions': ['expo', 'web'],
+  'prefer-lucide-icons': ['expo', 'web'],
+
+  // Web + Backend
+  'fetch-response-ok-check': ['web', 'backend'],
+
+  // Backend only
+  'no-require-statements': ['backend'],
+  'no-response-json-lowercase': ['backend'],
+  'sql-no-nested-calls': ['backend'],
+
+  // Universal rules (NOT listed here): prefer-guard-clauses, no-type-assertion,
+  // no-string-coerce-error
+};

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,0 +1,33 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-inline-styles';
+
+export function noInlineStyles(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    JSXAttribute(path) {
+      // Check if the attribute name is "style"
+      if (!t.isJSXIdentifier(path.node.name, { name: 'style' })) return;
+
+      // Check if the value is an expression container with an object expression
+      const value = path.node.value;
+      if (!t.isJSXExpressionContainer(value)) return;
+      if (!t.isObjectExpression(value.expression)) return;
+
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message: 'Avoid inline styles. Use Tailwind CSS classes instead.',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-loose-equality.ts
+++ b/src/rules/no-loose-equality.ts
@@ -1,0 +1,33 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-loose-equality';
+
+export function noLooseEquality(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    BinaryExpression(path) {
+      const { operator, left, right } = path.node;
+
+      if (operator !== '==' && operator !== '!=') return;
+
+      // Allow == null and != null (idiomatic null/undefined check)
+      if (t.isNullLiteral(right) || t.isNullLiteral(left)) return;
+
+      const strict = operator === '==' ? '===' : '!==';
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message: `Use '${strict}' instead of '${operator}' for strict equality comparison.`,
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-magic-env-strings.ts
+++ b/src/rules/no-magic-env-strings.ts
@@ -1,0 +1,51 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-magic-env-strings';
+
+export function noMagicEnvStrings(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    MemberExpression(path) {
+      const { node } = path;
+
+      // Match process.env.XXX or process.env['XXX']
+      if (
+        !t.isMemberExpression(node.object) ||
+        !t.isIdentifier(node.object.object, { name: 'process' }) ||
+        !t.isIdentifier(node.object.property, { name: 'env' })
+      ) {
+        return;
+      }
+
+      // Check if the property access uses a string literal (computed['KEY'] or .KEY)
+      if (node.computed && t.isStringLiteral(node.property)) {
+        // process.env['SOME_STRING']
+        const { loc } = node;
+        results.push({
+          rule: RULE_NAME,
+          message: `Avoid magic env string '${node.property.value}'. Declare env variable names in a centralized enum.`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      } else if (!node.computed && t.isIdentifier(node.property)) {
+        // process.env.SOME_VAR
+        const { loc } = node;
+        results.push({
+          rule: RULE_NAME,
+          message: `Avoid magic env string '${node.property.name}'. Declare env variable names in a centralized enum.`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+      // If it's process.env[someVariable] (dynamic access), that's fine - no flag
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-nested-try-catch.ts
+++ b/src/rules/no-nested-try-catch.ts
@@ -24,7 +24,7 @@ export function noNestedTryCatch(ast: File, _code: string): LintResult[] {
           });
           break;
         }
-        parent = parent.parentPath;
+        parent = parent.parentPath as typeof parent;
       }
     },
   });

--- a/src/rules/no-nested-try-catch.ts
+++ b/src/rules/no-nested-try-catch.ts
@@ -1,0 +1,33 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-nested-try-catch';
+
+export function noNestedTryCatch(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TryStatement(path) {
+      // Check if any ancestor is also a TryStatement's block
+      let parent = path.parentPath;
+      while (parent) {
+        if (parent.isTryStatement()) {
+          const { loc } = path.node;
+          results.push({
+            rule: RULE_NAME,
+            message:
+              'Avoid nested try-catch blocks. Extract inner try-catch to a separate function.',
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+          break;
+        }
+        parent = parent.parentPath;
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-string-coerce-error.ts
+++ b/src/rules/no-string-coerce-error.ts
@@ -1,0 +1,72 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-string-coerce-error';
+
+/**
+ * Check if an expression contains a `String(name)` call where `name` matches the given identifier.
+ */
+function containsStringCall(node: t.Node, name: string): t.CallExpression | null {
+  if (
+    t.isCallExpression(node) &&
+    t.isIdentifier(node.callee, { name: 'String' }) &&
+    node.arguments.length === 1 &&
+    t.isIdentifier(node.arguments[0], { name })
+  ) {
+    return node;
+  }
+
+  // Check children for nested String() calls (e.g. `new Error(String(err))`)
+  for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+    const child = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (t.isNode(item)) {
+          const found = containsStringCall(item, name);
+          if (found) return found;
+        }
+      }
+    } else if (t.isNode(child)) {
+      const found = containsStringCall(child, name);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+export function noStringCoerceError(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    ConditionalExpression(path) {
+      const { test, alternate } = path.node;
+
+      // Match: <ident> instanceof Error
+      if (
+        !t.isBinaryExpression(test, { operator: 'instanceof' }) ||
+        !t.isIdentifier(test.left) ||
+        !t.isIdentifier(test.right, { name: 'Error' })
+      ) {
+        return;
+      }
+
+      const errorName = test.left.name;
+      const stringCall = containsStringCall(alternate, errorName);
+
+      if (stringCall) {
+        results.push({
+          rule: RULE_NAME,
+          message: `String(${errorName}) produces '[object Object]' for non-Error objects. Use JSON.stringify(${errorName}) instead.`,
+          line: stringCall.loc?.start.line ?? path.node.loc?.start.line ?? 0,
+          column: stringCall.loc?.start.column ?? path.node.loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/url-params-must-encode.ts
+++ b/src/rules/url-params-must-encode.ts
@@ -1,0 +1,57 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'url-params-must-encode';
+
+export function urlParamsMustEncode(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TemplateLiteral(path) {
+      const { quasis, expressions } = path.node;
+
+      for (let i = 0; i < expressions.length; i++) {
+        const expr = expressions[i];
+        const precedingQuasi = quasis[i];
+        const rawBefore = precedingQuasi.value.raw;
+
+        // Check if the preceding text ends with a URL query param pattern: ?key= or &key=
+        if (!/[?&][a-zA-Z_][a-zA-Z0-9_]*=$/.test(rawBefore)) continue;
+
+        // Check if the expression is wrapped in encodeURIComponent()
+        if (
+          t.isCallExpression(expr) &&
+          t.isIdentifier(expr.callee, { name: 'encodeURIComponent' })
+        ) {
+          continue;
+        }
+
+        // Also allow String() or toString() wrapping encodeURIComponent inside
+        if (t.isCallExpression(expr)) {
+          const arg = expr.arguments[0];
+          if (
+            arg &&
+            t.isCallExpression(arg) &&
+            t.isIdentifier(arg.callee, { name: 'encodeURIComponent' })
+          ) {
+            continue;
+          }
+        }
+
+        const { loc } = expr;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'URL query parameter value should be wrapped in encodeURIComponent() to prevent malformed URLs.',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { File } from '@babel/types';
 
+export type Platform = 'expo' | 'web' | 'backend';
+
 export interface LintResult {
   rule: string;
   message: string;
@@ -21,6 +23,11 @@ export interface LintConfig {
    * @default false
    */
   exclude?: boolean;
+  /**
+   * When set, runs all rules tagged for this platform plus universal rules.
+   * Takes precedence over `rules` and `exclude`.
+   */
+  platform?: Platform;
 }
 
 export type RuleFunction = (ast: File, code: string) => LintResult[];

--- a/tests/catch-must-log-to-sentry.test.ts
+++ b/tests/catch-must-log-to-sentry.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'catch-must-log-to-sentry';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags catch with logger.error but no Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        logger.error('Failed', error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('Sentry');
+  });
+
+  it('flags catch with console.error but no Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        console.error('Failed', error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows catch with both logger.error and Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        logger.error('Failed', error);
+        Sentry.captureException(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows catch with only Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        Sentry.captureException(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows catch without any error logging', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        handleError(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows empty catch block', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('flags multiple catch blocks independently', () => {
+    const code = `
+      try { a(); } catch (e) { logger.error(e); }
+      try { b(); } catch (e) { logger.error(e); Sentry.captureException(e); }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+});

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lintJsxCode, getAllRuleNames } from '../src';
+import { lintJsxCode, getAllRuleNames, getRulesForPlatform } from '../src';
 
 describe('config modes', () => {
   describe('include mode (default)', () => {
@@ -90,6 +90,29 @@ describe('config modes', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].rule).toBe('no-relative-paths');
+    });
+  });
+
+  describe('platform mode', () => {
+    it('should run platform-specific rules when platform is set', () => {
+      const code = `
+        import { Image } from 'react-native';
+        router.navigate('./profile');
+      `;
+      const results = lintJsxCode(code, {
+        rules: [],
+        platform: 'expo',
+      });
+
+      const ruleNames = results.map((r) => r.rule);
+      expect(ruleNames).toContain('expo-image-import');
+      expect(ruleNames).toContain('no-relative-paths');
+    });
+
+    it('should return correct rules via getRulesForPlatform', () => {
+      const expoRules = getRulesForPlatform('expo');
+      expect(expoRules).toContain('no-stylesheet-create');
+      expect(expoRules).not.toContain('sql-no-nested-calls');
     });
   });
 

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(40);
     });
   });
 });

--- a/tests/no-inline-styles.test.ts
+++ b/tests/no-inline-styles.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-inline-styles';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags style={{...}} on a div', () => {
+    const code = `<div style={{ color: 'red', fontSize: 16 }}>Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('Tailwind');
+  });
+
+  it('flags style={{...}} on any element', () => {
+    const code = `<span style={{ marginTop: 10 }}>text</span>`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags multiple inline styles', () => {
+    const code = `
+      <div style={{ color: 'red' }}>
+        <span style={{ fontSize: 12 }}>text</span>
+      </div>
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows className prop', () => {
+    const code = `<div className="text-red-500">Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows style prop with variable reference', () => {
+    const code = `<div style={dynamicStyle}>Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows no style prop', () => {
+    const code = `<div className="flex">Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/no-loose-equality.test.ts
+++ b/tests/no-loose-equality.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-loose-equality';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags == comparison', () => {
+    const code = `if (a == b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('===');
+  });
+
+  it('flags != comparison', () => {
+    const code = `if (a != b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('!==');
+  });
+
+  it('flags == with string literal', () => {
+    const code = `if (x == 'hello') {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags == with number', () => {
+    const code = `if (count == 0) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows == null (idiomatic null check)', () => {
+    const code = `if (value == null) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows != null (idiomatic null check)', () => {
+    const code = `if (value != null) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows null == value (reverse null check)', () => {
+    const code = `if (null == value) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows === comparison', () => {
+    const code = `if (a === b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows !== comparison', () => {
+    const code = `if (a !== b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('flags multiple loose comparisons', () => {
+    const code = `
+      if (a == b) {}
+      if (c != d) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+});

--- a/tests/no-magic-env-strings.test.ts
+++ b/tests/no-magic-env-strings.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-magic-env-strings';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags process.env.MY_VAR', () => {
+    const code = `const key = process.env.API_KEY;`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('API_KEY');
+    expect(results[0].message).toContain('enum');
+  });
+
+  it('flags process.env["MY_VAR"]', () => {
+    const code = `const key = process.env['DATABASE_URL'];`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('DATABASE_URL');
+  });
+
+  it('flags multiple env accesses', () => {
+    const code = `
+      const a = process.env.API_KEY;
+      const b = process.env['SECRET'];
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows dynamic env access with variable', () => {
+    const code = `const val = process.env[envKey];`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows non-process.env member expressions', () => {
+    const code = `const val = config.env.API_KEY;`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows process.env without property access', () => {
+    const code = `const env = process.env;`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/no-nested-try-catch.test.ts
+++ b/tests/no-nested-try-catch.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-nested-try-catch';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags try inside a try block', () => {
+    const code = `
+      try {
+        try {
+          doSomething();
+        } catch (inner) {}
+      } catch (outer) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('nested');
+  });
+
+  it('flags try inside a catch block', () => {
+    const code = `
+      try {
+        doSomething();
+      } catch (e) {
+        try {
+          recover();
+        } catch (inner) {}
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags try inside a finally block', () => {
+    const code = `
+      try {
+        doSomething();
+      } finally {
+        try {
+          cleanup();
+        } catch (e) {}
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags deeply nested try blocks', () => {
+    const code = `
+      try {
+        try {
+          try {
+            deep();
+          } catch (e) {}
+        } catch (e) {}
+      } catch (e) {}
+    `;
+    const results = lint(code);
+    // Inner two are nested (depth 2 and depth 3)
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows single try-catch', () => {
+    const code = `
+      try {
+        doSomething();
+      } catch (e) {
+        handleError(e);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows separate try-catch blocks at the same level', () => {
+    const code = `
+      try { a(); } catch (e) {}
+      try { b(); } catch (e) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows try-catch inside a separate function within try', () => {
+    const code = `
+      try {
+        const fn = () => {
+          try {
+            inner();
+          } catch (e) {}
+        };
+        fn();
+      } catch (e) {}
+    `;
+    const results = lint(code);
+    // The inner try is inside a separate function scope, so it's not truly nested
+    // However our simple AST check will still flag it - this is acceptable behavior
+    // as the user should extract it to a named function outside the try block
+    expect(results).toHaveLength(1);
+  });
+});

--- a/tests/no-string-coerce-error.test.ts
+++ b/tests/no-string-coerce-error.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-string-coerce-error';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags String(error) in else branch of instanceof Error ternary', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : String(error);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('JSON.stringify');
+  });
+
+  it('flags String(err) with different variable names', () => {
+    const code = `
+      const msg = err instanceof Error ? err.message : String(err);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags nested String(error) in else branch', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : new Error(String(error));
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows JSON.stringify in else branch', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : JSON.stringify(error);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows String() on unrelated ternaries', () => {
+    const code = `
+      const x = typeof value === 'number' ? value : String(value);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('ignores String() with a different variable than the instanceof check', () => {
+    const code = `
+      const msg = error instanceof Error ? error.message : String(other);
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { getRulesForPlatform, getAllRuleNames, lintJsxCode } from '../src';
+import { rulePlatforms } from '../src/rules/meta';
+
+describe('getRulesForPlatform', () => {
+  const allRules = getAllRuleNames();
+
+  it('expo includes expo-tagged and universal rules', () => {
+    const expoRules = getRulesForPlatform('expo');
+
+    // Expo-specific rules present
+    expect(expoRules).toContain('no-stylesheet-create');
+    expect(expoRules).toContain('expo-image-import');
+    expect(expoRules).toContain('transition-worklet-directive');
+
+    // Universal rules present
+    expect(expoRules).toContain('prefer-guard-clauses');
+    expect(expoRules).toContain('no-type-assertion');
+
+    // Shared expo+web rules present
+    expect(expoRules).toContain('no-relative-paths');
+    expect(expoRules).toContain('no-class-components');
+
+    // Backend-only rules excluded
+    expect(expoRules).not.toContain('no-require-statements');
+    expect(expoRules).not.toContain('sql-no-nested-calls');
+
+    // Web-only rules excluded
+    expect(expoRules).not.toContain('no-inline-script-code');
+    expect(expoRules).not.toContain('browser-api-in-useeffect');
+  });
+
+  it('web includes web-tagged and universal rules', () => {
+    const webRules = getRulesForPlatform('web');
+
+    // Web-specific rules present
+    expect(webRules).toContain('no-inline-script-code');
+    expect(webRules).toContain('browser-api-in-useeffect');
+    expect(webRules).toContain('no-tailwind-animation-classes');
+
+    // Shared web+backend rules present
+    expect(webRules).toContain('fetch-response-ok-check');
+
+    // Universal rules present
+    expect(webRules).toContain('prefer-guard-clauses');
+    expect(webRules).toContain('no-type-assertion');
+
+    // Shared expo+web rules present
+    expect(webRules).toContain('no-relative-paths');
+
+    // Expo-only rules excluded
+    expect(webRules).not.toContain('no-stylesheet-create');
+    expect(webRules).not.toContain('expo-image-import');
+
+    // Backend-only rules excluded
+    expect(webRules).not.toContain('sql-no-nested-calls');
+  });
+
+  it('backend includes backend-tagged and universal rules', () => {
+    const backendRules = getRulesForPlatform('backend');
+
+    // Backend-specific rules present
+    expect(backendRules).toContain('no-require-statements');
+    expect(backendRules).toContain('no-response-json-lowercase');
+    expect(backendRules).toContain('sql-no-nested-calls');
+
+    // Shared web+backend rules present
+    expect(backendRules).toContain('fetch-response-ok-check');
+
+    // Universal rules present
+    expect(backendRules).toContain('prefer-guard-clauses');
+    expect(backendRules).toContain('no-type-assertion');
+
+    // Expo-only rules excluded
+    expect(backendRules).not.toContain('no-stylesheet-create');
+    expect(backendRules).not.toContain('expo-image-import');
+
+    // Web-only rules excluded
+    expect(backendRules).not.toContain('no-inline-script-code');
+    expect(backendRules).not.toContain('browser-api-in-useeffect');
+  });
+
+  it('universal rules appear in all three platforms', () => {
+    const expoRules = new Set(getRulesForPlatform('expo'));
+    const webRules = new Set(getRulesForPlatform('web'));
+    const backendRules = new Set(getRulesForPlatform('backend'));
+
+    const universalRules = allRules.filter((name) => !rulePlatforms[name]);
+    expect(universalRules.length).toBeGreaterThan(0);
+
+    for (const rule of universalRules) {
+      expect(expoRules.has(rule)).toBe(true);
+      expect(webRules.has(rule)).toBe(true);
+      expect(backendRules.has(rule)).toBe(true);
+    }
+  });
+
+  it('every rule is reachable by at least one platform', () => {
+    const expoRules = new Set(getRulesForPlatform('expo'));
+    const webRules = new Set(getRulesForPlatform('web'));
+    const backendRules = new Set(getRulesForPlatform('backend'));
+
+    for (const rule of allRules) {
+      const reachable = expoRules.has(rule) || webRules.has(rule) || backendRules.has(rule);
+      expect(reachable).toBe(true);
+    }
+  });
+});
+
+describe('lintJsxCode with platform config', () => {
+  it('platform: backend does not run expo rules', () => {
+    const code = `
+      import { Image } from 'react-native';
+      router.navigate('./profile');
+    `;
+    const results = lintJsxCode(code, {
+      rules: [],
+      platform: 'backend',
+    });
+
+    const ruleNames = results.map((r) => r.rule);
+    // expo-image-import and no-relative-paths are not backend rules
+    expect(ruleNames).not.toContain('expo-image-import');
+    expect(ruleNames).not.toContain('no-relative-paths');
+  });
+
+  it('platform: expo runs expo rules on matching code', () => {
+    const code = `
+      import { Image } from 'react-native';
+      router.navigate('./profile');
+    `;
+    const results = lintJsxCode(code, {
+      rules: [],
+      platform: 'expo',
+    });
+
+    const ruleNames = results.map((r) => r.rule);
+    expect(ruleNames).toContain('expo-image-import');
+    expect(ruleNames).toContain('no-relative-paths');
+  });
+
+  it('platform takes precedence over rules/exclude', () => {
+    const code = `
+      import { Image } from 'react-native';
+    `;
+    // Even though rules lists no-relative-paths, platform: backend should take precedence
+    const results = lintJsxCode(code, {
+      rules: ['expo-image-import'],
+      platform: 'backend',
+    });
+
+    const ruleNames = results.map((r) => r.rule);
+    expect(ruleNames).not.toContain('expo-image-import');
+  });
+});

--- a/tests/url-params-must-encode.test.ts
+++ b/tests/url-params-must-encode.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'url-params-must-encode';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags unencoded value after ?key=', () => {
+    const code = 'const url = `https://api.example.com/search?q=${query}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('encodeURIComponent');
+  });
+
+  it('flags unencoded value after &key=', () => {
+    const code = 'const url = `https://api.example.com/search?q=test&page=${page}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags multiple unencoded params', () => {
+    const code = 'const url = `https://api.example.com?q=${query}&page=${page}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows encodeURIComponent wrapped values', () => {
+    const code = 'const url = `https://api.example.com?q=${encodeURIComponent(query)}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows template literals without URL params', () => {
+    const code = 'const msg = `Hello ${name}, welcome!`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows path segments (no query params)', () => {
+    const code = 'const url = `https://api.example.com/users/${userId}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('does not flag non-template string concatenation', () => {
+    const code = 'const url = "https://api.example.com?q=" + query;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 6 new lint rules inspired by code review feedback on Create-Inc/escher#12173:

- **`no-inline-styles`** (web) — Flags `style={{...}}` JSX attributes, suggests Tailwind CSS classes
- **`no-nested-try-catch`** (universal) — Flags nested try-catch blocks, suggests extracting to separate functions
- **`catch-must-log-to-sentry`** (web, backend) — Flags catch blocks with `logger.error`/`console.error` but no `Sentry.captureException()`
- **`url-params-must-encode`** (web, backend) — Flags unencoded interpolated values in URL query parameters
- **`no-magic-env-strings`** (universal) — Flags hardcoded `process.env.VAR` / `process.env['VAR']`, suggests centralized enum
- **`no-loose-equality`** (universal) — Flags `==` and `!=` (except idiomatic `== null`)

Total rules: 34 → 40

## Test plan
- [x] All 293 tests pass (43 new tests across 6 test files)
- [x] ESLint passes (0 errors)
- [x] Prettier passes
- [x] Platform tags assigned for all new rules