### PR TITLE
Add no-inline-styles lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -149,6 +149,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | Rule                            | Severity | Description                                            |
 | ------------------------------- | -------- | ------------------------------------------------------ |
 | `no-tailwind-animation-classes` | warning  | Avoid animate-\* classes, use style jsx global instead |
+| `no-inline-styles`              | warning  | Avoid inline styles, use Tailwind CSS classes instead  |
 
 ### Backend / SQL Rules
 
@@ -418,6 +419,16 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-inline-styles`
+
+```tsx
+// Bad - inline style objects
+<div style={{ color: 'red', fontSize: 16 }}>Hello</div>
+
+// Good - Tailwind CSS classes
+<div className="text-red-500 text-base">Hello</div>
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noInlineStyles } from './no-inline-styles';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-inline-styles': noInlineStyles,
 };

--- a/src/rules/no-inline-styles.ts
+++ b/src/rules/no-inline-styles.ts
@@ -1,0 +1,33 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-inline-styles';
+
+export function noInlineStyles(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    JSXAttribute(path) {
+      // Check if the attribute name is "style"
+      if (!t.isJSXIdentifier(path.node.name, { name: 'style' })) return;
+
+      // Check if the value is an expression container with an object expression
+      const value = path.node.value;
+      if (!t.isJSXExpressionContainer(value)) return;
+      if (!t.isObjectExpression(value.expression)) return;
+
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message: 'Avoid inline styles. Use Tailwind CSS classes instead.',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-inline-styles.test.ts
+++ b/tests/no-inline-styles.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-inline-styles';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags style={{...}} on a div', () => {
+    const code = `<div style={{ color: 'red', fontSize: 16 }}>Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('Tailwind');
+  });
+
+  it('flags style={{...}} on any element', () => {
+    const code = `<span style={{ marginTop: 10 }}>text</span>`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags multiple inline styles', () => {
+    const code = `
+      <div style={{ color: 'red' }}>
+        <span style={{ fontSize: 12 }}>text</span>
+      </div>
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows className prop', () => {
+    const code = `<div className="text-red-500">Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows style prop with variable reference', () => {
+    const code = `<div style={dynamicStyle}>Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows no style prop', () => {
+    const code = `<div className="flex">Hello</div>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-inline-styles` rule that flags `style={{...}}` JSX attributes and suggests using Tailwind CSS classes instead
- Allows style props with variable references (e.g., `style={dynamicStyle}`)

## Test plan
- [x] All existing tests pass
- [x] 6 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes