### PR TITLE
Add catch-must-log-to-sentry lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -157,6 +157,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | `no-require-statements`      | error    | Use ES imports, not CommonJS require                          |
 | `no-response-json-lowercase` | warning  | Use Response.json() instead of new Response(JSON.stringify()) |
 | `sql-no-nested-calls`        | error    | Don't nest sql template tags                                  |
+
+### Error Handling Rules
+
+| Rule                       | Severity | Description                                                        |
+| -------------------------- | -------- | ------------------------------------------------------------------ |
+| `catch-must-log-to-sentry` | warning  | Catch blocks with logger.error/console.error must also call Sentry |
 
 ### Code Style Rules
 
@@ -418,6 +424,25 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `catch-must-log-to-sentry`
+
+```typescript
+// Bad - logs error but no Sentry
+try {
+  fetchData();
+} catch (error) {
+  logger.error('Failed', error);
+}
+
+// Good - both logging and Sentry
+try {
+  fetchData();
+} catch (error) {
+  logger.error('Failed', error);
+  Sentry.captureException(error);
+}
 ```
 
 ---

--- a/src/rules/catch-must-log-to-sentry.ts
+++ b/src/rules/catch-must-log-to-sentry.ts
@@ -1,0 +1,66 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'catch-must-log-to-sentry';
+
+/**
+ * Recursively check if a node contains a call matching `object.method` pattern.
+ */
+function containsCall(node: t.Node, objectName: string, methodName: string): boolean {
+  if (
+    t.isCallExpression(node) &&
+    t.isMemberExpression(node.callee) &&
+    t.isIdentifier(node.callee.object, { name: objectName }) &&
+    t.isIdentifier(node.callee.property, { name: methodName })
+  ) {
+    return true;
+  }
+
+  for (const key of t.VISITOR_KEYS[node.type] ?? []) {
+    const child = (node as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (t.isNode(item) && containsCall(item, objectName, methodName)) return true;
+      }
+    } else if (t.isNode(child) && containsCall(child, objectName, methodName)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function containsErrorLogging(node: t.Node): boolean {
+  return containsCall(node, 'logger', 'error') || containsCall(node, 'console', 'error');
+}
+
+function containsSentryCapture(node: t.Node): boolean {
+  return containsCall(node, 'Sentry', 'captureException');
+}
+
+export function catchMustLogToSentry(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CatchClause(path) {
+      const body = path.node.body;
+
+      // Only flag if catch block has error logging but no Sentry
+      if (containsErrorLogging(body) && !containsSentryCapture(body)) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Catch block logs an error but does not call Sentry.captureException(). Add Sentry reporting.',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { catchMustLogToSentry } from './catch-must-log-to-sentry';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'catch-must-log-to-sentry': catchMustLogToSentry,
 };

--- a/tests/catch-must-log-to-sentry.test.ts
+++ b/tests/catch-must-log-to-sentry.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'catch-must-log-to-sentry';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags catch with logger.error but no Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        logger.error('Failed', error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('Sentry');
+  });
+
+  it('flags catch with console.error but no Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        console.error('Failed', error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows catch with both logger.error and Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        logger.error('Failed', error);
+        Sentry.captureException(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows catch with only Sentry', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        Sentry.captureException(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows catch without any error logging', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {
+        handleError(error);
+      }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows empty catch block', () => {
+    const code = `
+      try {
+        fetchData();
+      } catch (error) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('flags multiple catch blocks independently', () => {
+    const code = `
+      try { a(); } catch (e) { logger.error(e); }
+      try { b(); } catch (e) { logger.error(e); Sentry.captureException(e); }
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+});

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -124,10 +124,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
 
-
-
       expect(ruleNames.length).toBe(41);
-
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `catch-must-log-to-sentry` rule that flags catch blocks containing `logger.error()` or `console.error()` without a corresponding `Sentry.captureException()` call
- Does not flag catch blocks without error logging (no false positives for handled errors)

## Test plan
- [x] All existing tests pass
- [x] 7 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes