### PR TITLE
Add url-params-must-encode lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -157,6 +157,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | `no-require-statements`      | error    | Use ES imports, not CommonJS require                          |
 | `no-response-json-lowercase` | warning  | Use Response.json() instead of new Response(JSON.stringify()) |
 | `sql-no-nested-calls`        | error    | Don't nest sql template tags                                  |
+
+### Error Handling Rules
+
+| Rule                     | Severity | Description                                                    |
+| ------------------------ | -------- | -------------------------------------------------------------- |
+| `url-params-must-encode` | warning  | URL query param values must be wrapped in encodeURIComponent() |
 
 ### Code Style Rules
 
@@ -418,6 +424,16 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `url-params-must-encode`
+
+```typescript
+// Bad - unencoded query param
+const url = `https://api.example.com?q=${query}`;
+
+// Good - encoded query param
+const url = `https://api.example.com?q=${encodeURIComponent(query)}`;
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { urlParamsMustEncode } from './url-params-must-encode';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'url-params-must-encode': urlParamsMustEncode,
 };

--- a/src/rules/url-params-must-encode.ts
+++ b/src/rules/url-params-must-encode.ts
@@ -1,0 +1,57 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'url-params-must-encode';
+
+export function urlParamsMustEncode(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TemplateLiteral(path) {
+      const { quasis, expressions } = path.node;
+
+      for (let i = 0; i < expressions.length; i++) {
+        const expr = expressions[i];
+        const precedingQuasi = quasis[i];
+        const rawBefore = precedingQuasi.value.raw;
+
+        // Check if the preceding text ends with a URL query param pattern: ?key= or &key=
+        if (!/[?&][a-zA-Z_][a-zA-Z0-9_]*=$/.test(rawBefore)) continue;
+
+        // Check if the expression is wrapped in encodeURIComponent()
+        if (
+          t.isCallExpression(expr) &&
+          t.isIdentifier(expr.callee, { name: 'encodeURIComponent' })
+        ) {
+          continue;
+        }
+
+        // Also allow String() or toString() wrapping encodeURIComponent inside
+        if (t.isCallExpression(expr)) {
+          const arg = expr.arguments[0];
+          if (
+            arg &&
+            t.isCallExpression(arg) &&
+            t.isIdentifier(arg.callee, { name: 'encodeURIComponent' })
+          ) {
+            continue;
+          }
+        }
+
+        const { loc } = expr;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'URL query parameter value should be wrapped in encodeURIComponent() to prevent malformed URLs.',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/url-params-must-encode.ts
+++ b/src/rules/url-params-must-encode.ts
@@ -28,7 +28,7 @@ export function urlParamsMustEncode(ast: File, _code: string): LintResult[] {
           continue;
         }
 
-        // Also allow String() or toString() wrapping encodeURIComponent inside
+        // Also allow function calls wrapping encodeURIComponent, e.g. String(encodeURIComponent(...))
         if (t.isCallExpression(expr)) {
           const arg = expr.arguments[0];
           if (

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/url-params-must-encode.test.ts
+++ b/tests/url-params-must-encode.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'url-params-must-encode';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags unencoded value after ?key=', () => {
+    const code = 'const url = `https://api.example.com/search?q=${query}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('encodeURIComponent');
+  });
+
+  it('flags unencoded value after &key=', () => {
+    const code = 'const url = `https://api.example.com/search?q=test&page=${page}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags multiple unencoded params', () => {
+    const code = 'const url = `https://api.example.com?q=${query}&page=${page}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows encodeURIComponent wrapped values', () => {
+    const code = 'const url = `https://api.example.com?q=${encodeURIComponent(query)}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows template literals without URL params', () => {
+    const code = 'const msg = `Hello ${name}, welcome!`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows path segments (no query params)', () => {
+    const code = 'const url = `https://api.example.com/users/${userId}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('does not flag non-template string concatenation', () => {
+    const code = 'const url = "https://api.example.com?q=" + query;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/url-params-must-encode.test.ts
+++ b/tests/url-params-must-encode.test.ts
@@ -46,6 +46,12 @@ describe(RULE, () => {
     expect(results).toHaveLength(0);
   });
 
+  it('allows String(encodeURIComponent(...)) wrapped values', () => {
+    const code = 'const url = `https://api.example.com?q=${String(encodeURIComponent(query))}`;';
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
   it('does not flag non-template string concatenation', () => {
     const code = 'const url = "https://api.example.com?q=" + query;';
     const results = lint(code);


### PR DESCRIPTION
## Summary
- Adds `url-params-must-encode` rule that flags template literal interpolations in URL query parameter positions not wrapped in `encodeURIComponent()`
- Detects `?key=${value}` and `&key=${value}` patterns
- Allows `encodeURIComponent()` wrapping and nested wrapping

## Test plan
- [x] All existing tests pass
- [x] 7 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes