### PR TITLE
Add no-magic-env-strings lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -160,10 +160,11 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 
 ### Code Style Rules
 
-| Rule                   | Severity | Description                                               |
-| ---------------------- | -------- | --------------------------------------------------------- |
-| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
-| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| Rule                   | Severity | Description                                                    |
+| ---------------------- | -------- | -------------------------------------------------------------- |
+| `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements             |
+| `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types      |
+| `no-magic-env-strings` | warning  | Use centralized enum for env variable names, not magic strings |
 
 ### General Rules
 
@@ -418,6 +419,17 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-magic-env-strings`
+
+```typescript
+// Bad - hardcoded env string
+const key = process.env.API_KEY;
+const url = process.env['DATABASE_URL'];
+
+// Good - use centralized enum
+const key = process.env[EnvVars.API_KEY];
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noMagicEnvStrings } from './no-magic-env-strings';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-magic-env-strings': noMagicEnvStrings,
 };

--- a/src/rules/no-magic-env-strings.ts
+++ b/src/rules/no-magic-env-strings.ts
@@ -1,0 +1,51 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-magic-env-strings';
+
+export function noMagicEnvStrings(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    MemberExpression(path) {
+      const { node } = path;
+
+      // Match process.env.XXX or process.env['XXX']
+      if (
+        !t.isMemberExpression(node.object) ||
+        !t.isIdentifier(node.object.object, { name: 'process' }) ||
+        !t.isIdentifier(node.object.property, { name: 'env' })
+      ) {
+        return;
+      }
+
+      // Check if the property access uses a string literal (computed['KEY'] or .KEY)
+      if (node.computed && t.isStringLiteral(node.property)) {
+        // process.env['SOME_STRING']
+        const { loc } = node;
+        results.push({
+          rule: RULE_NAME,
+          message: `Avoid magic env string '${node.property.value}'. Declare env variable names in a centralized enum.`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      } else if (!node.computed && t.isIdentifier(node.property)) {
+        // process.env.SOME_VAR
+        const { loc } = node;
+        results.push({
+          rule: RULE_NAME,
+          message: `Avoid magic env string '${node.property.name}'. Declare env variable names in a centralized enum.`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+      // If it's process.env[someVariable] (dynamic access), that's fine - no flag
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-magic-env-strings.test.ts
+++ b/tests/no-magic-env-strings.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-magic-env-strings';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags process.env.MY_VAR', () => {
+    const code = `const key = process.env.API_KEY;`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('API_KEY');
+    expect(results[0].message).toContain('enum');
+  });
+
+  it('flags process.env["MY_VAR"]', () => {
+    const code = `const key = process.env['DATABASE_URL'];`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('DATABASE_URL');
+  });
+
+  it('flags multiple env accesses', () => {
+    const code = `
+      const a = process.env.API_KEY;
+      const b = process.env['SECRET'];
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('allows dynamic env access with variable', () => {
+    const code = `const val = process.env[envKey];`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows non-process.env member expressions', () => {
+    const code = `const val = config.env.API_KEY;`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows process.env without property access', () => {
+    const code = `const env = process.env;`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-magic-env-strings` rule that flags `process.env.VAR_NAME` and `process.env['VAR_NAME']` direct string accesses
- Suggests using a centralized enum for environment variable names
- Allows dynamic access via variables (e.g., `process.env[envKey]`)

## Test plan
- [x] All existing tests pass
- [x] 6 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes