### PR TITLE
Add no-loose-equality lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-loose-equality`    | warning  | Use === and !== instead of == and != (except == null)     |
 
 ### General Rules
 
@@ -418,6 +419,26 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-loose-equality`
+
+```typescript
+// Bad - loose equality
+if (a == b) {
+}
+if (x != 'hello') {
+}
+
+// Good - strict equality
+if (a === b) {
+}
+if (x !== 'hello') {
+}
+
+// OK - == null is idiomatic for null/undefined check
+if (value == null) {
+}
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noLooseEquality } from './no-loose-equality';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-loose-equality': noLooseEquality,
 };

--- a/src/rules/no-loose-equality.ts
+++ b/src/rules/no-loose-equality.ts
@@ -1,0 +1,33 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-loose-equality';
+
+export function noLooseEquality(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    BinaryExpression(path) {
+      const { operator, left, right } = path.node;
+
+      if (operator !== '==' && operator !== '!=') return;
+
+      // Allow == null and != null (idiomatic null/undefined check)
+      if (t.isNullLiteral(right) || t.isNullLiteral(left)) return;
+
+      const strict = operator === '==' ? '===' : '!==';
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message: `Use '${strict}' instead of '${operator}' for strict equality comparison.`,
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-loose-equality.test.ts
+++ b/tests/no-loose-equality.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-loose-equality';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags == comparison', () => {
+    const code = `if (a == b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('===');
+  });
+
+  it('flags != comparison', () => {
+    const code = `if (a != b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('!==');
+  });
+
+  it('flags == with string literal', () => {
+    const code = `if (x == 'hello') {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags == with number', () => {
+    const code = `if (count == 0) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows == null (idiomatic null check)', () => {
+    const code = `if (value == null) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows != null (idiomatic null check)', () => {
+    const code = `if (value != null) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows null == value (reverse null check)', () => {
+    const code = `if (null == value) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows === comparison', () => {
+    const code = `if (a === b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows !== comparison', () => {
+    const code = `if (a !== b) {}`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('flags multiple loose comparisons', () => {
+    const code = `
+      if (a == b) {}
+      if (c != d) {}
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-loose-equality` rule that flags `==` and `!=` operators, suggesting `===` and `!==` instead
- Allows `== null` and `!= null` as idiomatic null/undefined checks

## Test plan
- [x] All existing tests pass
- [x] 10 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes