### PR TITLE
Add no-deprecated-react-apis rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | --------------------- | -------- | --------------------------------------------- |
 | `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
 
+### Agent Code Quality Rules
+
+| Rule                       | Severity | Description                                                            |
+| -------------------------- | -------- | ---------------------------------------------------------------------- |
+| `no-deprecated-react-apis` | warning  | Detect deprecated React APIs like defaultProps, propTypes, string refs |
+
 ---
 
 ## Rule Details

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,7 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noDeprecatedReactApis } from './no-deprecated-react-apis';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +70,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-deprecated-react-apis': noDeprecatedReactApis,
 };

--- a/src/rules/no-deprecated-react-apis.ts
+++ b/src/rules/no-deprecated-react-apis.ts
@@ -1,0 +1,108 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-deprecated-react-apis';
+
+const DEPRECATED_LIFECYCLE_METHODS = new Set([
+  'componentWillMount',
+  'componentWillReceiveProps',
+  'componentWillUpdate',
+  'UNSAFE_componentWillMount',
+  'UNSAFE_componentWillReceiveProps',
+  'UNSAFE_componentWillUpdate',
+]);
+
+export function noDeprecatedReactApis(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    // Detect deprecated lifecycle methods in class components
+    ClassMethod(path) {
+      const { key, loc } = path.node;
+      if (key.type !== 'Identifier') return;
+
+      if (DEPRECATED_LIFECYCLE_METHODS.has(key.name)) {
+        results.push({
+          rule: RULE_NAME,
+          message: `"${key.name}" is deprecated. Use function components with hooks instead`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+
+    // Detect static defaultProps
+    ClassProperty(path) {
+      const { key, static: isStatic, loc } = path.node;
+      if (key.type !== 'Identifier') return;
+
+      if (isStatic && key.name === 'defaultProps') {
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Static "defaultProps" is deprecated. Use default parameter values in function components instead',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+
+      if (key.name === 'propTypes') {
+        results.push({
+          rule: RULE_NAME,
+          message: '"propTypes" is deprecated. Use TypeScript types or interfaces instead',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+
+    // Detect Component.defaultProps = ... and Component.propTypes = ...
+    AssignmentExpression(path) {
+      const { left, loc } = path.node;
+
+      if (left.type === 'MemberExpression' && left.property.type === 'Identifier') {
+        if (left.property.name === 'defaultProps') {
+          results.push({
+            rule: RULE_NAME,
+            message:
+              '"defaultProps" is deprecated. Use default parameter values in function components instead',
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+        }
+
+        if (left.property.name === 'propTypes') {
+          results.push({
+            rule: RULE_NAME,
+            message: '"propTypes" is deprecated. Use TypeScript types or interfaces instead',
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+        }
+      }
+    },
+
+    // Detect string refs: ref="myRef"
+    JSXAttribute(path) {
+      const { name, value, loc } = path.node;
+
+      if (name.type === 'JSXIdentifier' && name.name === 'ref' && value?.type === 'StringLiteral') {
+        results.push({
+          rule: RULE_NAME,
+          message: 'String refs are deprecated. Use useRef() hook or callback refs instead',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/no-deprecated-react-apis.test.ts
+++ b/tests/no-deprecated-react-apis.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-deprecated-react-apis'] };
+
+describe('no-deprecated-react-apis rule', () => {
+  it('should detect componentWillMount', () => {
+    const code = `
+      class MyComponent extends Component {
+        componentWillMount() {
+          this.setup();
+        }
+        render() { return <div />; }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-deprecated-react-apis');
+    expect(results[0].message).toContain('componentWillMount');
+  });
+
+  it('should detect componentWillReceiveProps', () => {
+    const code = `
+      class MyComponent extends Component {
+        componentWillReceiveProps(nextProps) {
+          this.update(nextProps);
+        }
+        render() { return <div />; }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect UNSAFE_ lifecycle methods', () => {
+    const code = `
+      class MyComponent extends Component {
+        UNSAFE_componentWillMount() {}
+        UNSAFE_componentWillUpdate() {}
+        render() { return <div />; }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(2);
+  });
+
+  it('should detect static defaultProps', () => {
+    const code = `
+      class MyComponent extends Component {
+        static defaultProps = { name: 'World' };
+        render() { return <div />; }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('defaultProps');
+  });
+
+  it('should detect Component.defaultProps assignment', () => {
+    const code = `
+      function MyComponent({ name }) { return <div>{name}</div>; }
+      MyComponent.defaultProps = { name: 'World' };
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect propTypes', () => {
+    const code = `
+      MyComponent.propTypes = { name: PropTypes.string };
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('propTypes');
+  });
+
+  it('should detect string refs', () => {
+    const code = `
+      function MyComponent() {
+        return <input ref="myInput" />;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('String refs');
+  });
+
+  it('should allow useRef', () => {
+    const code = `
+      function MyComponent() {
+        const ref = useRef(null);
+        return <input ref={ref} />;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callback refs', () => {
+    const code = `
+      function MyComponent() {
+        return <input ref={(el) => { inputRef = el; }} />;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow modern lifecycle methods', () => {
+    const code = `
+      class MyComponent extends Component {
+        componentDidMount() {}
+        componentDidUpdate() {}
+        componentWillUnmount() {}
+        render() { return <div />; }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-deprecated-react-apis` rule that detects deprecated React patterns
- Catches: `componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`, `UNSAFE_` lifecycle methods, `defaultProps`, `propTypes`, string refs
- Severity: warning

## Test plan
- [x] Detects deprecated lifecycle methods (componentWillMount, etc.)
- [x] Detects UNSAFE_ lifecycle methods
- [x] Detects static defaultProps and Component.defaultProps assignments
- [x] Detects propTypes usage
- [x] Detects string refs
- [x] Allows useRef, callback refs, modern lifecycle methods
- [x] Config modes test updated with new rule count

🤖 Generated with [Claude Code](https://claude.com/claude-code)