### PR TITLE
Add no-any-type rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | --------------------- | -------- | --------------------------------------------- |
 | `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
 
+### Agent Code Quality Rules
+
+| Rule          | Severity | Description                       |
+| ------------- | -------- | --------------------------------- |
+| `no-any-type` | warning  | Avoid using TypeScript "any" type |
+
 ---
 
 ## Rule Details

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,7 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noAnyType } from './no-any-type';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +70,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-any-type': noAnyType,
 };

--- a/src/rules/no-any-type.ts
+++ b/src/rules/no-any-type.ts
@@ -1,0 +1,24 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-any-type';
+
+export function noAnyType(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    TSAnyKeyword(path) {
+      const { loc } = path.node;
+      results.push({
+        rule: RULE_NAME,
+        message: 'Avoid using "any" type. Use a specific type, "unknown", or a generic instead',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/no-any-type.test.ts
+++ b/tests/no-any-type.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-any-type'] };
+
+describe('no-any-type rule', () => {
+  it('should detect any in variable type annotation', () => {
+    const code = `const x: any = 5;`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-any-type');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should detect any in function parameter', () => {
+    const code = `function foo(x: any) { return x; }`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect any in return type', () => {
+    const code = `function foo(): any { return 5; }`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect any in generic type parameter', () => {
+    const code = `const items: Array<any> = [];`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect multiple any usages', () => {
+    const code = `
+      function process(input: any): any {
+        const temp: any = input;
+        return temp;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(3);
+  });
+
+  it('should allow unknown type', () => {
+    const code = `const x: unknown = 5;`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow specific types', () => {
+    const code = `const x: string = 'hello';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow generic types', () => {
+    const code = `function identity<T>(x: T): T { return x; }`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should detect any in interface properties', () => {
+    const code = `
+      interface Foo {
+        data: any;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect any in type aliases', () => {
+    const code = `type Callback = (event: any) => void;`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-any-type` rule that flags usage of TypeScript `any` type
- Catches `any` in variable annotations, function parameters, return types, generics, interfaces, and type aliases
- Severity: warning

## Test plan
- [x] Detects `any` in variable annotations, parameters, return types, generics
- [x] Detects multiple `any` usages in single function
- [x] Detects `any` in interfaces and type aliases
- [x] Allows `unknown`, specific types, and generics
- [x] Config modes test updated with new rule count

🤖 Generated with [Claude Code](https://claude.com/claude-code)