### PR TITLE
Add no-floating-promises rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | --------------------- | -------- | --------------------------------------------- |
 | `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
 
+### Agent Code Quality Rules
+
+| Rule                   | Severity | Description                                               |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| `no-floating-promises` | warning  | Catch unhandled promises from fetch, .json(), async IIFEs |
+
 ---
 
 ## Rule Details

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,7 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noFloatingPromises } from './no-floating-promises';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +70,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-floating-promises': noFloatingPromises,
 };

--- a/src/rules/no-floating-promises.ts
+++ b/src/rules/no-floating-promises.ts
@@ -1,0 +1,73 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-floating-promises';
+
+// Known async functions/methods that return promises
+const KNOWN_ASYNC_FUNCTIONS = new Set(['fetch']);
+
+const KNOWN_ASYNC_METHODS = new Set(['json', 'text', 'blob', 'arrayBuffer', 'formData']);
+
+export function noFloatingPromises(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    ExpressionStatement(path) {
+      const { expression, loc } = path.node;
+
+      if (expression.type !== 'CallExpression') return;
+
+      // Check for: fetch(...) as a standalone statement
+      if (
+        expression.callee.type === 'Identifier' &&
+        KNOWN_ASYNC_FUNCTIONS.has(expression.callee.name)
+      ) {
+        results.push({
+          rule: RULE_NAME,
+          message: `"${expression.callee.name}()" returns a Promise. Use "await" or handle the Promise`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+        return;
+      }
+
+      // Check for: foo.json(), foo.text() etc. as standalone statements
+      if (
+        expression.callee.type === 'MemberExpression' &&
+        expression.callee.property.type === 'Identifier' &&
+        KNOWN_ASYNC_METHODS.has(expression.callee.property.name)
+      ) {
+        results.push({
+          rule: RULE_NAME,
+          message: `".${expression.callee.property.name}()" returns a Promise. Use "await" or handle the Promise`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+        return;
+      }
+
+      // Check for: calling an async arrow/function expression without await
+      // e.g., (async () => { ... })()
+      if (
+        expression.callee.type === 'ArrowFunctionExpression' ||
+        expression.callee.type === 'FunctionExpression'
+      ) {
+        if (expression.callee.async) {
+          results.push({
+            rule: RULE_NAME,
+            message:
+              'Immediately-invoked async function returns a Promise. Use "await" or handle the Promise',
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+        }
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/no-floating-promises.test.ts
+++ b/tests/no-floating-promises.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-floating-promises'] };
+
+describe('no-floating-promises rule', () => {
+  it('should detect floating fetch() calls', () => {
+    const code = `fetch('/api/data');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-floating-promises');
+    expect(results[0].message).toContain('fetch()');
+  });
+
+  it('should detect floating .json() calls', () => {
+    const code = `response.json();`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('.json()');
+  });
+
+  it('should detect floating .text() calls', () => {
+    const code = `response.text();`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect floating IIFE async functions', () => {
+    const code = `(async () => { await doStuff(); })();`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('async function');
+  });
+
+  it('should allow awaited fetch', () => {
+    const code = `const res = await fetch('/api/data');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow fetch assigned to variable', () => {
+    const code = `const promise = fetch('/api/data');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow fetch with .then()', () => {
+    const code = `fetch('/api/data').then(r => r.json());`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag non-async IIFE', () => {
+    const code = `(() => { doStuff(); })();`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag regular function calls', () => {
+    const code = `doSomething();`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-floating-promises` rule that catches unhandled promises
- Detects: standalone `fetch()` calls, `.json()`/`.text()` without await, immediately-invoked async functions
- Works without type information by checking known async APIs
- Severity: warning

## Test plan
- [x] Detects floating fetch() calls
- [x] Detects floating .json(), .text() calls
- [x] Detects floating IIFE async functions
- [x] Allows awaited fetch, fetch assigned to variable, fetch with .then()
- [x] Does not flag non-async IIFEs or regular function calls
- [x] Config modes test updated with new rule count

🤖 Generated with [Claude Code](https://claude.com/claude-code)