### PR TITLE
Add no-console-log rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | --------------------- | -------- | --------------------------------------------- |
 | `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
 
+### Agent Code Quality Rules
+
+| Rule             | Severity | Description                                     |
+| ---------------- | -------- | ----------------------------------------------- |
+| `no-console-log` | warning  | Remove console.log statements before committing |
+
 ---
 
 ## Rule Details

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,7 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noConsoleLog } from './no-console-log';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +70,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-console-log': noConsoleLog,
 };

--- a/src/rules/no-console-log.ts
+++ b/src/rules/no-console-log.ts
@@ -1,0 +1,34 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-console-log';
+
+export function noConsoleLog(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CallExpression(path) {
+      const { callee, loc } = path.node;
+
+      if (
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier' &&
+        callee.object.name === 'console' &&
+        callee.property.type === 'Identifier' &&
+        callee.property.name === 'log'
+      ) {
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Remove console.log statement. Use a proper logging library or remove before committing',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/no-console-log.test.ts
+++ b/tests/no-console-log.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-console-log'] };
+
+describe('no-console-log rule', () => {
+  it('should detect console.log calls', () => {
+    const code = `console.log('hello');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-console-log');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should detect console.log in functions', () => {
+    const code = `
+      function debug() {
+        console.log('debugging');
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect multiple console.log calls', () => {
+    const code = `
+      console.log('first');
+      console.log('second');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(2);
+  });
+
+  it('should not flag console.error', () => {
+    const code = `console.error('something went wrong');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag console.warn', () => {
+    const code = `console.warn('deprecation warning');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag console.info', () => {
+    const code = `console.info('server started');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag other function calls', () => {
+    const code = `logger.log('hello');`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag code without console', () => {
+    const code = `const x = 5;`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-console-log` rule that detects `console.log` statements
- Only flags `console.log`, not `console.error`, `console.warn`, or `console.info`
- Severity: warning

## Test plan
- [x] Detects console.log calls in various contexts
- [x] Detects multiple console.log calls
- [x] Does not flag console.error, console.warn, console.info
- [x] Does not flag other logging libraries (e.g., logger.log)
- [x] Config modes test updated with new rule count

🤖 Generated with [Claude Code](https://claude.com/claude-code)