### PR TITLE
Add no-hardcoded-secrets rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | --------------------- | -------- | --------------------------------------------- |
 | `prefer-lucide-icons` | warning  | Prefer lucide-react/lucide-react-native icons |
 
+### Agent Code Quality Rules
+
+| Rule                   | Severity | Description                                      |
+| ---------------------- | -------- | ------------------------------------------------ |
+| `no-hardcoded-secrets` | error    | Detect hardcoded API keys, tokens, and passwords |
+
 ---
 
 ## Rule Details

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -33,6 +33,7 @@ import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noHardcodedSecrets } from './no-hardcoded-secrets';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -69,4 +70,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-hardcoded-secrets': noHardcodedSecrets,
 };

--- a/src/rules/no-hardcoded-secrets.ts
+++ b/src/rules/no-hardcoded-secrets.ts
@@ -1,0 +1,119 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-hardcoded-secrets';
+
+// Variable/property name patterns that suggest secrets
+const SECRET_NAME_PATTERNS = [
+  /api[_-]?key/i,
+  /api[_-]?secret/i,
+  /secret[_-]?key/i,
+  /access[_-]?key/i,
+  /access[_-]?token/i,
+  /auth[_-]?token/i,
+  /private[_-]?key/i,
+  /client[_-]?secret/i,
+  /password/i,
+  /passwd/i,
+  /database[_-]?url/i,
+  /connection[_-]?string/i,
+  /credentials/i,
+];
+
+// Value patterns that look like actual secrets
+const SECRET_VALUE_PATTERNS = [
+  /^sk[-_][a-zA-Z0-9_-]{20,}/, // Stripe-style keys
+  /^pk[-_][a-zA-Z0-9_-]{20,}/, // Stripe public keys
+  /^ghp_[a-zA-Z0-9]{36,}/, // GitHub personal access tokens
+  /^gho_[a-zA-Z0-9]{36,}/, // GitHub OAuth tokens
+  /^github_pat_/, // GitHub fine-grained PATs
+  /^xox[bporas]-/, // Slack tokens
+  /^eyJ[a-zA-Z0-9_-]{20,}\.eyJ/, // JWTs
+  /^AKIA[0-9A-Z]{16}/, // AWS access key IDs
+  /^AIza[0-9A-Za-z_-]{35}/, // Google API keys
+];
+
+function isSecretName(name: string): boolean {
+  return SECRET_NAME_PATTERNS.some((p) => p.test(name));
+}
+
+function isSecretValue(value: string): boolean {
+  return SECRET_VALUE_PATTERNS.some((p) => p.test(value));
+}
+
+export function noHardcodedSecrets(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const { id, init, loc } = path.node;
+
+      if (id.type !== 'Identifier' || !init) return;
+      if (init.type !== 'StringLiteral' && init.type !== 'TemplateLiteral') return;
+
+      const value =
+        init.type === 'StringLiteral'
+          ? init.value
+          : (init.quasis?.map((q) => q.value.raw).join('') ?? '');
+
+      // Check if variable name suggests a secret and value looks non-trivial
+      if (isSecretName(id.name) && value.length > 0) {
+        // Allow references to env vars like process.env.X or empty strings
+        if (value === '' || value.startsWith('process.env')) return;
+
+        results.push({
+          rule: RULE_NAME,
+          message: `Possible hardcoded secret in "${id.name}". Use environment variables instead`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'error',
+        });
+        return;
+      }
+
+      // Check if the value itself looks like a known secret format
+      if (init.type === 'StringLiteral' && isSecretValue(value)) {
+        results.push({
+          rule: RULE_NAME,
+          message: `Possible hardcoded secret (detected known token pattern). Use environment variables instead`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'error',
+        });
+      }
+    },
+
+    ObjectProperty(path) {
+      const { key, value, loc } = path.node;
+
+      let keyName: string | null = null;
+      if (key.type === 'Identifier') keyName = key.name;
+      else if (key.type === 'StringLiteral') keyName = key.value;
+
+      if (!keyName || value.type !== 'StringLiteral') return;
+
+      if (isSecretName(keyName) && value.value.length > 0) {
+        results.push({
+          rule: RULE_NAME,
+          message: `Possible hardcoded secret in "${keyName}". Use environment variables instead`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'error',
+        });
+      }
+
+      if (isSecretValue(value.value)) {
+        results.push({
+          rule: RULE_NAME,
+          message: `Possible hardcoded secret (detected known token pattern). Use environment variables instead`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'error',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(34);
+      expect(ruleNames.length).toBe(35);
     });
   });
 });

--- a/tests/no-hardcoded-secrets.test.ts
+++ b/tests/no-hardcoded-secrets.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-hardcoded-secrets'] };
+
+describe('no-hardcoded-secrets rule', () => {
+  it('should detect hardcoded API keys', () => {
+    const code = `const apiKey = 'my-secret-api-key-12345';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-hardcoded-secrets');
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('should detect hardcoded passwords', () => {
+    const code = `const password = 'hunter2';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect hardcoded tokens in objects', () => {
+    const code = `const config = { authToken: 'abc123secret' };`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect Stripe-style secret keys by value pattern', () => {
+    const code = `const key = 'sk-test-fakefakefakefakefakefake';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect GitHub tokens by value pattern', () => {
+    const code = `const token = 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx00';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect AWS access keys by value pattern', () => {
+    const code = `const key = 'AKIAIOSFODNN7EXAMPLE';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect database URLs', () => {
+    const code = `const databaseUrl = 'postgresql://user:pass@host:5432/db';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should allow environment variable references', () => {
+    const code = `const apiKey = process.env.API_KEY;`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow non-secret string variables', () => {
+    const code = `const name = 'John Doe';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow empty strings for secret-named variables', () => {
+    const code = `const apiKey = '';`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag regular config objects', () => {
+    const code = `const config = { timeout: '30s', retries: '3' };`;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-hardcoded-secrets` rule that detects hardcoded API keys, tokens, passwords, and connection strings
- Two detection strategies: suspicious variable/property names + known secret value patterns (Stripe, GitHub, AWS, JWTs)
- Severity: error

## Test plan
- [x] Detects hardcoded API keys, passwords, auth tokens, database URLs
- [x] Detects known token patterns (Stripe, GitHub, AWS)
- [x] Allows environment variable references
- [x] Allows empty strings and non-secret variables
- [x] Config modes test updated with new rule count

🤖 Generated with [Claude Code](https://claude.com/claude-code)