### PR TITLE
Add no-new-error-in-err lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const allResults = lintJsxCode(code, {
 const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import', ...]
 ```
 
-## Available Rules (33 total)
+## Available Rules (34 total)
 
 ### Expo Router Rules
 
@@ -164,6 +164,7 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 | ---------------------- | -------- | --------------------------------------------------------- |
 | `prefer-guard-clauses` | warning  | Use early returns instead of nesting if statements        |
 | `no-type-assertion`    | warning  | Avoid `as` type casts; use type narrowing or proper types |
+| `no-new-error-in-err`  | warning  | Don't construct Error objects inside neverthrow err()     |
 
 ### General Rules
 
@@ -418,6 +419,19 @@ if (typeof data === 'string') {
 
 // Good - proper typing
 const user: User = response.data;
+```
+
+### `no-new-error-in-err`
+
+```typescript
+// Bad - constructing Error inside neverthrow err()
+return err(new Error('Failed to detect pull request', { cause: error }));
+
+// Good - use a plain object
+return err({ message: 'Failed to detect pull request', cause: error });
+
+// Good - use a string
+return err('Failed to detect pull request');
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -32,6 +32,7 @@ import { transitionSharedTagMismatch } from './transition-shared-tag-mismatch';
 import { transitionPreferBlankStack } from './transition-prefer-blank-stack';
 import { preferGuardClauses } from './prefer-guard-clauses';
 import { noTypeAssertion } from './no-type-assertion';
+import { noNewErrorInErr } from './no-new-error-in-err';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -67,4 +68,5 @@ export const rules: Record<string, RuleFunction> = {
   'transition-prefer-blank-stack': transitionPreferBlankStack,
   'prefer-guard-clauses': preferGuardClauses,
   'no-type-assertion': noTypeAssertion,
+  'no-new-error-in-err': noNewErrorInErr,
 };

--- a/src/rules/no-new-error-in-err.ts
+++ b/src/rules/no-new-error-in-err.ts
@@ -1,0 +1,37 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-new-error-in-err';
+
+export function noNewErrorInErr(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    CallExpression(path) {
+      const { callee, arguments: args } = path.node;
+
+      // Match err(...) calls
+      if (!t.isIdentifier(callee, { name: 'err' })) return;
+      if (args.length === 0) return;
+
+      const firstArg = args[0];
+
+      // Flag err(new Error(...))
+      if (t.isNewExpression(firstArg) && t.isIdentifier(firstArg.callee, { name: 'Error' })) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message:
+            'Avoid constructing Error objects inside err(). Use a plain object or custom error type instead (e.g. err({ message: "...", cause: error })).',
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -100,7 +100,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(33);
+      expect(ruleNames.length).toBe(34);
     });
   });
 });

--- a/tests/no-new-error-in-err.test.ts
+++ b/tests/no-new-error-in-err.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-new-error-in-err';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags err(new Error("message"))', () => {
+    const code = `function f() { return err(new Error('Something failed')); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].message).toContain('plain object');
+  });
+
+  it('flags err(new Error("message", { cause }))', () => {
+    const code = `function f() { return err(new Error('Failed to detect pull request', { cause: error })); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags err(new Error()) with no args', () => {
+    const code = `function f() { return err(new Error()); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('flags err(new Error()) in expression position', () => {
+    const code = `const result = err(new Error('failed'));`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('allows err("string message")', () => {
+    const code = `function f() { return err('Something failed'); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows err({ message, cause })', () => {
+    const code = `function f() { return err({ message: 'Failed', cause: error }); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows err(someVariable)', () => {
+    const code = `function f() { return err(existingError); }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows new Error outside err()', () => {
+    const code = `throw new Error('Something failed');`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows other function calls with new Error', () => {
+    const code = `logError(new Error('Something failed'));`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-new-error-in-err` rule that flags `err(new Error(...))` — constructing exception objects inside neverthrow's `err()` wrapper
- Suggests using plain objects or strings instead (e.g. `err({ message: '...', cause: error })`)

## Test plan
- [x] All existing tests pass
- [x] 9 new tests pass
- [x] TypeScript compiles
- [x] Prettier passes