### PR TITLE
Add no-sync-fs rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ const backendRules = getRulesForPlatform('backend');
 | `no-require-statements`      | error    | backend  | Use ES imports, not CommonJS require                          |
 | `no-response-json-lowercase` | warning  | backend  | Use Response.json() instead of new Response(JSON.stringify()) |
 | `sql-no-nested-calls`        | error    | backend  | Don't nest sql template tags                                  |
+| `no-sync-fs`                 | error    | backend  | Use fs.promises or fs/promises instead of sync fs methods     |
 
 ### URL Rules
 
@@ -684,6 +685,20 @@ interface UserProps {
   name: string | null;
   age: number | null;
 }
+```
+
+### `no-sync-fs`
+
+```typescript
+// Bad - synchronous fs methods block the event loop
+import fs from 'fs';
+const data = fs.readFileSync('file.txt', 'utf-8');
+fs.writeFileSync('output.txt', data);
+
+// Good - use async fs methods
+import { readFile, writeFile } from 'fs/promises';
+const data = await readFile('file.txt', 'utf-8');
+await writeFile('output.txt', data);
 ```
 
 ## Adding a New Rule

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -45,6 +45,7 @@ import { noOptionalProps } from './no-optional-props';
 import { noSilentSkip } from './no-silent-skip';
 import { noManualRetryLoop } from './no-manual-retry-loop';
 import { noEmojiIcons } from './no-emoji-icons';
+import { noSyncFs } from './no-sync-fs';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -93,4 +94,5 @@ export const rules: Record<string, RuleFunction> = {
   'no-silent-skip': noSilentSkip,
   'no-manual-retry-loop': noManualRetryLoop,
   'no-emoji-icons': noEmojiIcons,
+  'no-sync-fs': noSyncFs,
 };

--- a/src/rules/meta.ts
+++ b/src/rules/meta.ts
@@ -45,6 +45,7 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
   'no-require-statements': ['backend'],
   'no-response-json-lowercase': ['backend'],
   'sql-no-nested-calls': ['backend'],
+  'no-sync-fs': ['backend'],
 
   // Universal rules (NOT listed here): prefer-guard-clauses, no-type-assertion,
   // no-string-coerce-error

--- a/src/rules/no-sync-fs.ts
+++ b/src/rules/no-sync-fs.ts
@@ -1,0 +1,96 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-sync-fs';
+
+function isSyncMethod(name: string): boolean {
+  return name.endsWith('Sync');
+}
+
+function isFsSource(source: string): boolean {
+  return source === 'fs' || source === 'node:fs';
+}
+
+function asyncAlternative(methodName: string): string {
+  const name = methodName.replace(/Sync$/, '');
+  return `fs.promises.${name}`;
+}
+
+export function noSyncFs(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  // Collect identifiers imported/required from 'fs' or 'node:fs'
+  const fsImportedNames = new Set<string>();
+
+  traverse(ast, {
+    // import { readFileSync } from 'fs'
+    ImportDeclaration(path) {
+      if (!isFsSource(path.node.source.value)) return;
+
+      for (const specifier of path.node.specifiers) {
+        if (t.isImportSpecifier(specifier) && t.isIdentifier(specifier.local)) {
+          const imported = t.isIdentifier(specifier.imported)
+            ? specifier.imported.name
+            : specifier.imported.value;
+          if (isSyncMethod(imported)) {
+            fsImportedNames.add(specifier.local.name);
+          }
+        }
+        // import fs from 'fs' or import * as fs from 'fs'
+        if (
+          t.isImportDefaultSpecifier(specifier) ||
+          t.isImportNamespaceSpecifier(specifier)
+        ) {
+          fsImportedNames.add(specifier.local.name);
+        }
+      }
+    },
+
+    CallExpression(path) {
+      const { callee, loc } = path.node;
+
+      // Pattern 1: fs.readFileSync(...)
+      if (
+        t.isMemberExpression(callee) &&
+        t.isIdentifier(callee.property) &&
+        isSyncMethod(callee.property.name)
+      ) {
+        const objectName = t.isIdentifier(callee.object)
+          ? callee.object.name
+          : null;
+
+        // Only flag if the object is a known fs import or literally named 'fs'
+        if (objectName === 'fs' || fsImportedNames.has(objectName ?? '')) {
+          const method = callee.property.name;
+          results.push({
+            rule: RULE_NAME,
+            message: `Use ${asyncAlternative(method)} or import from 'fs/promises' instead of ${method}`,
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'error',
+          });
+        }
+      }
+
+      // Pattern 2: readFileSync(...) — direct import from 'fs'
+      if (
+        t.isIdentifier(callee) &&
+        isSyncMethod(callee.name) &&
+        fsImportedNames.has(callee.name)
+      ) {
+        const method = callee.name;
+        results.push({
+          rule: RULE_NAME,
+          message: `Use ${asyncAlternative(method)} or import from 'fs/promises' instead of ${method}`,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'error',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-sync-fs.ts
+++ b/src/rules/no-sync-fs.ts
@@ -39,10 +39,7 @@ export function noSyncFs(ast: File, _code: string): LintResult[] {
           }
         }
         // import fs from 'fs' or import * as fs from 'fs'
-        if (
-          t.isImportDefaultSpecifier(specifier) ||
-          t.isImportNamespaceSpecifier(specifier)
-        ) {
+        if (t.isImportDefaultSpecifier(specifier) || t.isImportNamespaceSpecifier(specifier)) {
           fsImportedNames.add(specifier.local.name);
         }
       }
@@ -57,9 +54,7 @@ export function noSyncFs(ast: File, _code: string): LintResult[] {
         t.isIdentifier(callee.property) &&
         isSyncMethod(callee.property.name)
       ) {
-        const objectName = t.isIdentifier(callee.object)
-          ? callee.object.name
-          : null;
+        const objectName = t.isIdentifier(callee.object) ? callee.object.name : null;
 
         // Only flag if the object is a known fs import or literally named 'fs'
         if (objectName === 'fs' || fsImportedNames.has(objectName ?? '')) {
@@ -75,11 +70,7 @@ export function noSyncFs(ast: File, _code: string): LintResult[] {
       }
 
       // Pattern 2: readFileSync(...) — direct import from 'fs'
-      if (
-        t.isIdentifier(callee) &&
-        isSyncMethod(callee.name) &&
-        fsImportedNames.has(callee.name)
-      ) {
+      if (t.isIdentifier(callee) && isSyncMethod(callee.name) && fsImportedNames.has(callee.name)) {
         const method = callee.name;
         results.push({
           rule: RULE_NAME,

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(46);
+      expect(ruleNames.length).toBe(47);
     });
   });
 });

--- a/tests/no-sync-fs.test.ts
+++ b/tests/no-sync-fs.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-sync-fs'] };
+
+function lint(code: string) {
+  return lintJsxCode(code, config);
+}
+
+describe('no-sync-fs', () => {
+  it('should flag fs.readFileSync()', () => {
+    const code = `import fs from 'fs';\nfs.readFileSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-sync-fs');
+    expect(results[0].message).toContain('fs.promises.readFile');
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('should flag fs.writeFileSync()', () => {
+    const code = `import fs from 'fs';\nfs.writeFileSync('file.txt', 'data');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('fs.promises.writeFile');
+  });
+
+  it('should flag fs.existsSync()', () => {
+    const code = `import fs from 'fs';\nfs.existsSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('fs.promises.exists');
+  });
+
+  it('should flag fs.mkdirSync()', () => {
+    const code = `import fs from 'fs';\nfs.mkdirSync('dir');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('fs.promises.mkdir');
+  });
+
+  it('should flag destructured sync imports from fs', () => {
+    const code = `import { readFileSync } from 'fs';\nreadFileSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-sync-fs');
+    expect(results[0].message).toContain('fs.promises.readFile');
+  });
+
+  it('should flag multiple destructured sync imports', () => {
+    const code = `import { readFileSync, writeFileSync } from 'fs';\nreadFileSync('a');\nwriteFileSync('b', 'c');`;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('should flag imports from node:fs', () => {
+    const code = `import fs from 'node:fs';\nfs.readFileSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should flag namespace imports from fs', () => {
+    const code = `import * as fs from 'fs';\nfs.statSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('fs.promises.stat');
+  });
+
+  it('should flag multiple sync calls', () => {
+    const code = `import fs from 'fs';\nfs.readFileSync('a');\nfs.writeFileSync('b', 'c');\nfs.mkdirSync('d');`;
+    const results = lint(code);
+    expect(results).toHaveLength(3);
+  });
+
+  // --- Should allow ---
+
+  it('should allow fs.promises.readFile()', () => {
+    const code = `import fs from 'fs';\nawait fs.promises.readFile('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow imports from fs/promises', () => {
+    const code = `import { readFile } from 'fs/promises';\nawait readFile('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow async callback-style fs methods', () => {
+    const code = `import fs from 'fs';\nfs.readFile('file.txt', (err, data) => {});`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag readFileSync on non-fs objects', () => {
+    const code = `someObj.readFileSync('file.txt');`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag a function named readFileSync unrelated to fs', () => {
+    const code = `function readFileSync() { return 'mock'; }\nreadFileSync();`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Flags synchronous `fs` methods (`readFileSync`, `writeFileSync`, `existsSync`, etc.) and suggests `fs.promises` or `fs/promises` instead
- Detects both `fs.xSync()` member calls and destructured imports from `'fs'`/`'node:fs'`
- Uses `endsWith('Sync')` instead of a hardcoded method list — future-proof against new Node.js fs additions
- Tagged as `backend` platform only
- Codifies the code style preference from our escher CLAUDE.md: "Always use `fs.promises.*` instead of sync variants"

## Test plan

| Scenario | Expected |
|----------|----------|
| `npm test` | All 350 tests pass (14 new for this rule) |
| `fs.readFileSync(...)` | Flagged with suggestion to use `fs.promises.readFile` |
| `import { writeFileSync } from 'fs'` then `writeFileSync(...)` | Flagged |
| `import fs from 'node:fs'` then `fs.existsSync(...)` | Flagged |
| `await fs.promises.readFile(...)` | Allowed |
| `import { readFile } from 'fs/promises'` | Allowed |
| `someObj.readFileSync(...)` | Allowed (not an fs import) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)