### PR TITLE
Add prefer-named-params rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,7 @@ function createUser({ name, email, age }: { name: string; email: string; age: nu
 Callbacks (`.map`, `.filter`, `.reduce`, `.sort`, `.then`, etc.) and `React.forwardRef`/`memo` are excluded.
 
 ---
+
 ## Adding a New Rule
 
 1. Create a rule file in `src/rules/`:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ const backendRules = getRulesForPlatform('backend');
 | `no-silent-skip`         | warning  | universal | Add else branch with logging instead of silently skipping        |
 | `no-manual-retry-loop`   | warning  | universal | Use a retry library instead of manual retry/polling loops        |
 | `no-emoji-icons`         | warning  | universal | Use icons from lucide-react instead of emoji characters          |
+| `prefer-named-params`   | warning  | universal | Use object destructuring instead of positional parameters        |
 
 ### General Rules
 
@@ -701,6 +702,23 @@ const data = await readFile('file.txt', 'utf-8');
 await writeFile('output.txt', data);
 ```
 
+### `prefer-named-params`
+
+```typescript
+// Bad - positional parameters
+function createUser(name: string, email: string, age: number) {
+  return { name, email, age };
+}
+
+// Good - named parameters via object destructuring
+function createUser({ name, email, age }: { name: string; email: string; age: number }) {
+  return { name, email, age };
+}
+```
+
+Callbacks (`.map`, `.filter`, `.reduce`, `.sort`, `.then`, etc.) and `React.forwardRef`/`memo` are excluded.
+
+---
 ## Adding a New Rule
 
 1. Create a rule file in `src/rules/`:

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ const backendRules = getRulesForPlatform('backend');
 | `no-silent-skip`         | warning  | universal | Add else branch with logging instead of silently skipping        |
 | `no-manual-retry-loop`   | warning  | universal | Use a retry library instead of manual retry/polling loops        |
 | `no-emoji-icons`         | warning  | universal | Use icons from lucide-react instead of emoji characters          |
-| `prefer-named-params`   | warning  | universal | Use object destructuring instead of positional parameters        |
+| `prefer-named-params`    | warning  | universal | Use object destructuring instead of positional parameters        |
 
 ### General Rules
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -46,6 +46,7 @@ import { noSilentSkip } from './no-silent-skip';
 import { noManualRetryLoop } from './no-manual-retry-loop';
 import { noEmojiIcons } from './no-emoji-icons';
 import { noSyncFs } from './no-sync-fs';
+import { preferNamedParams } from './prefer-named-params';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -95,4 +96,5 @@ export const rules: Record<string, RuleFunction> = {
   'no-manual-retry-loop': noManualRetryLoop,
   'no-emoji-icons': noEmojiIcons,
   'no-sync-fs': noSyncFs,
+  'prefer-named-params': preferNamedParams,
 };

--- a/src/rules/prefer-named-params.ts
+++ b/src/rules/prefer-named-params.ts
@@ -1,0 +1,112 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'prefer-named-params';
+
+// Callback-style methods where positional params are natural
+const CALLBACK_METHODS = new Set([
+  'map',
+  'forEach',
+  'filter',
+  'find',
+  'findIndex',
+  'some',
+  'every',
+  'reduce',
+  'reduceRight',
+  'flatMap',
+  'sort',
+  'then',
+  'catch',
+  'on',
+  'once',
+  'addEventListener',
+  'removeEventListener',
+  'subscribe',
+  'pipe',
+  'use',
+]);
+
+function isCallbackArg(path: traverse.NodePath<t.Function>): boolean {
+  const parent = path.parent;
+
+  // fn passed as argument to a function call: foo((a, b) => ...)
+  if (t.isCallExpression(parent)) {
+    return true;
+  }
+
+  // fn passed as argument to a method call: arr.map((item, index) => ...)
+  if (
+    t.isCallExpression(parent) &&
+    t.isMemberExpression(parent.callee) &&
+    t.isIdentifier(parent.callee.property) &&
+    CALLBACK_METHODS.has(parent.callee.property.name)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function isReactComponent(path: traverse.NodePath<t.Function>): boolean {
+  // React components have (props) or () — single param at most
+  // But check for forwardRef((props, ref) => ...) pattern
+  const parent = path.parent;
+  if (
+    t.isCallExpression(parent) &&
+    t.isIdentifier(parent.callee) &&
+    (parent.callee.name === 'forwardRef' || parent.callee.name === 'memo')
+  ) {
+    return true;
+  }
+  if (
+    t.isCallExpression(parent) &&
+    t.isMemberExpression(parent.callee) &&
+    t.isIdentifier(parent.callee.property) &&
+    (parent.callee.property.name === 'forwardRef' ||
+      parent.callee.property.name === 'memo')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function preferNamedParams(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression'(
+      path: traverse.NodePath<t.Function>,
+    ) {
+      const { params, loc } = path.node;
+
+      // Only flag when there are 2+ params
+      if (params.length < 2) return;
+
+      // Skip if first param is already destructured (object pattern)
+      if (t.isObjectPattern(params[0])) return;
+
+      // Skip callbacks passed as arguments
+      if (isCallbackArg(path)) return;
+
+      // Skip React.forwardRef / React.memo
+      if (isReactComponent(path)) return;
+
+      // Skip class methods and object methods
+      if (t.isClassMethod(path.parent) || t.isObjectMethod(path.parent)) return;
+
+      results.push({
+        rule: RULE_NAME,
+        message:
+          'Prefer named parameters using object destructuring instead of positional parameters',
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'warning',
+      });
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(47);
+      expect(ruleNames.length).toBe(48);
     });
   });
 });

--- a/tests/prefer-named-params.test.ts
+++ b/tests/prefer-named-params.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['prefer-named-params'] };
+
+function lint(code: string) {
+  return lintJsxCode(code, config);
+}
+
+describe('prefer-named-params', () => {
+  // --- Should flag ---
+
+  it('should flag function declarations with multiple positional params', () => {
+    const code = `function doThing(paramA: string, paramB: number) { return paramA; }`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('prefer-named-params');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should flag arrow functions with multiple positional params', () => {
+    const code = `const doThing = (paramA: string, paramB: number) => paramA;`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should flag function expressions with multiple positional params', () => {
+    const code = `const doThing = function(paramA: string, paramB: number) { return paramA; };`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should flag exported functions with multiple positional params', () => {
+    const code = `export function createUser(name: string, email: string) { return { name, email }; }`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+  });
+
+  // --- Should allow ---
+
+  it('should allow functions with a single parameter', () => {
+    const code = `function doThing(param: string) { return param; }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow functions with no parameters', () => {
+    const code = `function doThing() { return 'hello'; }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow functions using object destructuring', () => {
+    const code = `function doThing({ paramA, paramB }: { paramA: string; paramB: number }) { return paramA; }`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow arrow functions using object destructuring', () => {
+    const code = `const doThing = ({ a, b }: { a: string; b: number }) => a;`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .map()', () => {
+    const code = `const result = items.map((item, index) => item + index);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .filter()', () => {
+    const code = `const result = items.filter((item, index) => index > 0);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .reduce()', () => {
+    const code = `const result = items.reduce((acc, item) => acc + item, 0);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .forEach()', () => {
+    const code = `items.forEach((item, index) => console.log(item, index));`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .sort()', () => {
+    const code = `items.sort((a, b) => a - b);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed to .then()', () => {
+    const code = `fetch('/api').then((res, extra) => res.json());`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow callbacks passed as function arguments', () => {
+    const code = `setTimeout((a, b) => a + b, 1000);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow React.forwardRef callbacks', () => {
+    const code = `const MyComp = React.forwardRef((props, ref) => <div ref={ref} />);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow forwardRef callbacks', () => {
+    const code = `const MyComp = forwardRef((props, ref) => <div ref={ref} />);`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Flags functions with 2+ positional parameters, suggesting object destructuring instead
- Codifies CLAUDE.md: "Prefer to use named parameters (object destructuring) for functions"
- Skips callbacks (`.map`, `.filter`, `.reduce`, `.sort`, `.then`, etc.), `React.forwardRef`/`memo`, and functions already using destructured params
- Universal rule (not platform-specific)
- Severity: `warning`

## Test plan

| Scenario | Expected |
|----------|----------|
| `npm test` | All 353 tests pass (17 new for this rule) |
| `function doThing(a: string, b: number)` | Flagged |
| `const fn = (a, b) => a + b` (not a callback) | Flagged |
| `function doThing({ a, b }: { a: string; b: number })` | Allowed |
| `items.map((item, index) => ...)` | Allowed |
| `items.reduce((acc, item) => ...)` | Allowed |
| `forwardRef((props, ref) => ...)` | Allowed |
| `setTimeout((a, b) => ..., 1000)` | Allowed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)