### PR TITLE
Add no-emoji-icons lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ const backendRules = getRulesForPlatform('backend');
 | `no-optional-props`      | warning  | universal | Use `prop: T \| null` instead of `prop?: T` in interfaces        |
 | `no-silent-skip`         | warning  | universal | Add else branch with logging instead of silently skipping        |
 | `no-manual-retry-loop`   | warning  | universal | Use a retry library instead of manual retry/polling loops        |
+| `no-emoji-icons`         | warning  | universal | Use icons from lucide-react instead of emoji characters          |
 
 ### General Rules
 
@@ -630,6 +631,21 @@ const result = await retry(
   },
   { retries: 15, minTimeout: 2000 },
 );
+```
+
+---
+
+### `no-emoji-icons`
+
+```typescript
+// Bad - emoji characters as icons
+<Text>✅ Done</Text>
+<Button label="🔥 Hot" />
+
+// Good - use icon library
+import { Check, Flame } from 'lucide-react';
+<Text><Check /> Done</Text>
+<Button label={<><Flame /> Hot</>} />
 ```
 
 ---

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -44,6 +44,7 @@ import { loggerErrorWithErr } from './logger-error-with-err';
 import { noOptionalProps } from './no-optional-props';
 import { noSilentSkip } from './no-silent-skip';
 import { noManualRetryLoop } from './no-manual-retry-loop';
+import { noEmojiIcons } from './no-emoji-icons';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -91,4 +92,5 @@ export const rules: Record<string, RuleFunction> = {
   'no-optional-props': noOptionalProps,
   'no-silent-skip': noSilentSkip,
   'no-manual-retry-loop': noManualRetryLoop,
+  'no-emoji-icons': noEmojiIcons,
 };

--- a/src/rules/no-emoji-icons.ts
+++ b/src/rules/no-emoji-icons.ts
@@ -11,33 +11,31 @@ const EMOJI_REGEX =
 const MESSAGE =
   "Use icons from 'lucide-react' or 'lucide-react-native' instead of emoji characters";
 
+function checkNode(
+  node: { value: string; loc?: { start: { line: number; column: number } } | null },
+  results: LintResult[],
+) {
+  if (EMOJI_REGEX.test(node.value)) {
+    const { loc } = node;
+    results.push({
+      rule: RULE_NAME,
+      message: MESSAGE,
+      line: loc?.start.line ?? 0,
+      column: loc?.start.column ?? 0,
+      severity: 'warning',
+    });
+  }
+}
+
 export function noEmojiIcons(ast: File, _code: string): LintResult[] {
   const results: LintResult[] = [];
 
   traverse(ast, {
     StringLiteral(path) {
-      if (EMOJI_REGEX.test(path.node.value)) {
-        const { loc } = path.node;
-        results.push({
-          rule: RULE_NAME,
-          message: MESSAGE,
-          line: loc?.start.line ?? 0,
-          column: loc?.start.column ?? 0,
-          severity: 'warning',
-        });
-      }
+      checkNode(path.node, results);
     },
     JSXText(path) {
-      if (EMOJI_REGEX.test(path.node.value)) {
-        const { loc } = path.node;
-        results.push({
-          rule: RULE_NAME,
-          message: MESSAGE,
-          line: loc?.start.line ?? 0,
-          column: loc?.start.column ?? 0,
-          severity: 'warning',
-        });
-      }
+      checkNode(path.node, results);
     },
   });
 

--- a/src/rules/no-emoji-icons.ts
+++ b/src/rules/no-emoji-icons.ts
@@ -1,0 +1,45 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-emoji-icons';
+
+// Regex covering common emoji Unicode ranges
+const EMOJI_REGEX =
+  /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}\u{E0020}-\u{E007F}\u{2300}-\u{23FF}\u{2B50}\u{2B55}\u{231A}\u{231B}\u{23E9}-\u{23F3}\u{23F8}-\u{23FA}\u{25AA}\u{25AB}\u{25B6}\u{25C0}\u{25FB}-\u{25FE}\u{2934}\u{2935}\u{2B05}-\u{2B07}\u{3030}\u{303D}\u{3297}\u{3299}\u{2139}\u{2194}-\u{2199}\u{21A9}\u{21AA}\u{23CF}\u{24C2}\u{25AA}\u{25AB}\u{2122}\u{2328}\u{23ED}-\u{23EF}]/u;
+
+const MESSAGE =
+  "Use icons from 'lucide-react' or 'lucide-react-native' instead of emoji characters";
+
+export function noEmojiIcons(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    StringLiteral(path) {
+      if (EMOJI_REGEX.test(path.node.value)) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message: MESSAGE,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+    JSXText(path) {
+      if (EMOJI_REGEX.test(path.node.value)) {
+        const { loc } = path.node;
+        results.push({
+          rule: RULE_NAME,
+          message: MESSAGE,
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(45);
+      expect(ruleNames.length).toBe(46);
     });
   });
 });

--- a/tests/no-emoji-icons.test.ts
+++ b/tests/no-emoji-icons.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const RULE = 'no-emoji-icons';
+
+function lint(code: string) {
+  return lintJsxCode(code, { rules: [RULE] });
+}
+
+describe(RULE, () => {
+  it('flags emoji in JSXText', () => {
+    const code = `<Text>✅ Done</Text>`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+    expect(results[0].severity).toBe('warning');
+    expect(results[0].message).toContain('lucide-react');
+  });
+
+  it('flags emoji in string attribute', () => {
+    const code = `<Button label="🔥 Hot" />`;
+    const results = lint(code);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe(RULE);
+  });
+
+  it('flags multiple emoji occurrences', () => {
+    const code = `
+      <View>
+        <Text>⚠️ Warning</Text>
+        <Button label="🎉 Celebrate" />
+      </View>
+    `;
+    const results = lint(code);
+    expect(results).toHaveLength(2);
+  });
+
+  it('passes plain text without emoji', () => {
+    const code = `<Text>Hello world</Text>`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('passes icon component usage', () => {
+    const code = `<Icon name="check" />`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+
+  it('passes regular strings without emoji', () => {
+    const code = `const msg = "Hello world";`;
+    const results = lint(code);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `no-emoji-icons` rule that flags emoji characters in `JSXText` and `StringLiteral` nodes
- Recommends using `lucide-react` / `lucide-react-native` icon libraries instead
- Universal rule (all platforms), severity: warning

## Test plan
- [x] 6 new tests covering emoji in JSX text, string attributes, multiple occurrences, and clean passes
- [x] `npm test` — 349 tests pass
- [x] `npm run build` — compiles cleanly
- [x] `npm run lint` — 0 errors