### PR TITLE
fix: support custom variable names in expo-font-loaded-check

### DIFF
--- a/tests/expo-font-loaded-check.test.ts
+++ b/tests/expo-font-loaded-check.test.ts
@@ -54,6 +54,35 @@ describe('expo-font-loaded-check rule', () => {
     expect(results).toHaveLength(0);
   });
 
+  it('should allow useFonts with custom variable name for loaded state', () => {
+    const code = `
+      function Component() {
+        const [fontsLoaded, fontError] = useFonts({
+          Inter_400Regular,
+          Inter_600SemiBold,
+          Inter_700Bold,
+        });
+        if (!fontsLoaded && !fontError) {
+          return null;
+        }
+        return <Text style={{ fontFamily: 'Inter_400Regular' }}>Hello</Text>;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should detect useFonts with custom variable name but no check', () => {
+    const code = `
+      function Component() {
+        const [fontsLoaded, fontError] = useFonts({ Inter_400Regular });
+        return <Text>Hello</Text>;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
   it('should detect useFonts with incorrect check', () => {
     const code = `
       function Component() {


### PR DESCRIPTION
## Summary
- The `expo-font-loaded-check` rule previously only matched the exact variable name `loaded`
- Now it tracks the actual destructured variable name from `useFonts()` (e.g. `fontsLoaded`)
- Patterns like `if (!fontsLoaded && !fontError) return null` are now correctly recognized

## Example
```tsx
// This was incorrectly flagged before:
const [fontsLoaded, fontError] = useFonts({ Inter_400Regular });
if (!fontsLoaded && !fontError) return null;
```