### PR TITLE
feat: add no-module-level-new lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm install laint
 ## Programmatic Usage
 
 ```typescript
-import { lintJsxCode, getAllRuleNames } from "laint";
+import { lintJsxCode, getAllRuleNames } from 'laint';
 
 const code = `
   <Link href="./profile">Profile</Link>
@@ -72,7 +72,7 @@ const code = `
 
 // Include mode (default): only run specified rules
 const results = lintJsxCode(code, {
-  rules: ["no-relative-paths", "no-stylesheet-create", "expo-image-import"],
+  rules: ['no-relative-paths', 'no-stylesheet-create', 'expo-image-import'],
 });
 
 // results:
@@ -89,7 +89,7 @@ Run all rules except specific ones:
 ```typescript
 // Exclude mode: run ALL rules except those listed
 const results = lintJsxCode(code, {
-  rules: ["no-stylesheet-create"], // rules to skip
+  rules: ['no-stylesheet-create'], // rules to skip
   exclude: true,
 });
 
@@ -108,18 +108,18 @@ const ruleNames = getAllRuleNames(); // ['no-relative-paths', 'expo-image-import
 Run rules by platform — includes platform-tagged rules plus universal rules:
 
 ```typescript
-import { lintJsxCode, getRulesForPlatform } from "laint";
+import { lintJsxCode, getRulesForPlatform } from 'laint';
 
 // Run all rules for Expo
 const results = lintJsxCode(code, {
   rules: [],
-  platform: "expo",
+  platform: 'expo',
 });
 
 // Get rule names for a platform
-const expoRules = getRulesForPlatform("expo"); // expo-tagged + universal rules
-const webRules = getRulesForPlatform("web");
-const backendRules = getRulesForPlatform("backend");
+const expoRules = getRulesForPlatform('expo'); // expo-tagged + universal rules
+const webRules = getRulesForPlatform('web');
+const backendRules = getRulesForPlatform('backend');
 ```
 
 ## Available Rules (53 total)
@@ -277,11 +277,11 @@ function Component() {
 
 ```jsx
 // Bad
-const response = await fetch("/api/data");
+const response = await fetch('/api/data');
 const data = await response.json();
 
 // Good
-const response = await fetch("/api/data");
+const response = await fetch('/api/data');
 if (!response.ok) {
   throw new Error(`HTTP ${response.status}`);
 }
@@ -340,7 +340,7 @@ When using NativeTabs from expo-router/unstable-native-tabs, each screen needs 6
 
 ```tsx
 // Bad - uses hooks without "use client"
-import { useState } from "react";
+import { useState } from 'react';
 
 export function Counter() {
   const [count, setCount] = useState(0);
@@ -348,9 +348,9 @@ export function Counter() {
 }
 
 // Good - has "use client" directive
-("use client");
+('use client');
 
-import { useState } from "react";
+import { useState } from 'react';
 
 export function Counter() {
   const [count, setCount] = useState(0);
@@ -362,19 +362,19 @@ export function Counter() {
 
 ```tsx
 // Bad - server-only module in client file
-"use client";
+'use client';
 
-import { cookies } from "next/headers";
+import { cookies } from 'next/headers';
 
 export function UserMenu() {
   return <div>Menu</div>;
 }
 
 // Good - use server-only modules only in server components
-import { cookies } from "next/headers";
+import { cookies } from 'next/headers';
 
 export function UserMenu() {
-  const session = cookies().get("session");
+  const session = cookies().get('session');
   return <div>Menu</div>;
 }
 ```
@@ -421,7 +421,7 @@ const options = {
 // Good
 const options = {
   screenStyleInterpolator: (progress) => {
-    "worklet";
+    'worklet';
     return { opacity: progress };
   },
 };
@@ -432,14 +432,14 @@ const options = {
 ```jsx
 // Bad - only covers [0, 1], missing exit phase
 screenStyleInterpolator: (progress) => {
-  "worklet";
+  'worklet';
   const opacity = interpolate(progress, [0, 1], [0, 1]);
   return { opacity };
 };
 
 // Good - covers full [0, 1, 2] range
 screenStyleInterpolator: (progress) => {
-  "worklet";
+  'worklet';
   const opacity = interpolate(progress, [0, 1, 2], [0, 1, 0]);
   return { opacity };
 };
@@ -449,12 +449,12 @@ screenStyleInterpolator: (progress) => {
 
 ```jsx
 // Bad - regular ScrollView conflicts with transition gestures
-import { Transition } from "react-native-screen-transitions";
-import { ScrollView } from "react-native";
+import { Transition } from 'react-native-screen-transitions';
+import { ScrollView } from 'react-native';
 <ScrollView>...</ScrollView>;
 
 // Good
-import { Transition } from "react-native-screen-transitions";
+import { Transition } from 'react-native-screen-transitions';
 <Transition.ScrollView>...</Transition.ScrollView>;
 ```
 
@@ -482,7 +482,7 @@ import { Transition } from "react-native-screen-transitions";
 <Stack.Screen options={{ enableTransitions: true }} />;
 
 // Good - use Blank Stack from react-native-screen-transitions
-import { BlankStack } from "react-native-screen-transitions";
+import { BlankStack } from 'react-native-screen-transitions';
 ```
 
 ### `sql-no-nested-calls`
@@ -522,7 +522,7 @@ const value = data as string;
 const user = response.data as User;
 
 // Good - type narrowing
-if (typeof data === "string") {
+if (typeof data === 'string') {
   const value = data;
 }
 
@@ -536,13 +536,13 @@ const user: User = response.data;
 // Bad - loose equality
 if (a == b) {
 }
-if (x != "hello") {
+if (x != 'hello') {
 }
 
 // Good - strict equality
 if (a === b) {
 }
-if (x !== "hello") {
+if (x !== 'hello') {
 }
 
 // OK - == null is idiomatic for null/undefined check
@@ -577,14 +577,14 @@ const url = `https://api.example.com?q=${encodeURIComponent(query)}`;
 try {
   fetchData();
 } catch (error) {
-  logger.error("Failed", error);
+  logger.error('Failed', error);
 }
 
 // Good - both logging and Sentry
 try {
   fetchData();
 } catch (error) {
-  logger.error("Failed", error);
+  logger.error('Failed', error);
   Sentry.captureException(error);
 }
 ```
@@ -634,13 +634,13 @@ const message = error instanceof Error ? error.message : JSON.stringify(error);
 
 ```typescript
 // Bad - missing err property
-logger.error({}, "something failed");
-logger.error({ userId: 1 }, "request failed");
-logger.error("something went wrong");
+logger.error({}, 'something failed');
+logger.error({ userId: 1 }, 'request failed');
+logger.error('something went wrong');
 
 // Good - includes err for stack traces
-logger.error({ err: error }, "something failed");
-logger.error({ err: new Error("x"), userId: 1 }, "request failed");
+logger.error({ err: error }, 'something failed');
+logger.error({ err: new Error('x'), userId: 1 }, 'request failed');
 ```
 
 ### `no-silent-skip`
@@ -660,7 +660,7 @@ function process(user) {
     sendEmail(user);
     updateDb(user);
   } else {
-    logger.warn("No user provided, skipping processing");
+    logger.warn('No user provided, skipping processing');
   }
 }
 
@@ -683,11 +683,11 @@ for (let attempt = 0; attempt < 15; attempt++) {
 }
 
 // Good - use a retry library
-import retry from "async-retry";
+import retry from 'async-retry';
 const result = await retry(
   async () => {
     const res = await checkStatus(id);
-    if (!res.ready) throw new Error("not ready");
+    if (!res.ready) throw new Error('not ready');
     return res;
   },
   { retries: 15, minTimeout: 2000 },
@@ -721,7 +721,7 @@ const data = JSON.parse(rawInput);
 try {
   const data = JSON.parse(rawInput);
 } catch (e) {
-  console.error("Failed to parse JSON", e);
+  console.error('Failed to parse JSON', e);
 }
 
 // For JSON.stringify with circular references, consider using fast-safe-stringify
@@ -751,14 +751,14 @@ interface UserProps {
 
 ```typescript
 // Bad - synchronous fs methods block the event loop
-import fs from "fs";
-const data = fs.readFileSync("file.txt", "utf-8");
-fs.writeFileSync("output.txt", data);
+import fs from 'fs';
+const data = fs.readFileSync('file.txt', 'utf-8');
+fs.writeFileSync('output.txt', data);
 
 // Good - use async fs methods
-import { readFile, writeFile } from "fs/promises";
-const data = await readFile("file.txt", "utf-8");
-await writeFile("output.txt", data);
+import { readFile, writeFile } from 'fs/promises';
+const data = await readFile('file.txt', 'utf-8');
+await writeFile('output.txt', data);
 ```
 
 ### `prefer-named-params`
@@ -793,9 +793,9 @@ Callbacks (`.map`, `.filter`, `.reduce`, `.sort`, `.then`, etc.) and `React.forw
 
 ```typescript
 // src/rules/my-rule.ts
-import traverse from "@babel/traverse";
-import type { File } from "@babel/types";
-import type { LintResult } from "../types";
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
 
 export function myRule(ast: File, code: string): LintResult[] {
   const results: LintResult[] = [];
@@ -804,11 +804,11 @@ export function myRule(ast: File, code: string): LintResult[] {
     CallExpression(path) {
       // Check for violations...
       results.push({
-        rule: "my-rule",
-        message: "Description of the issue",
+        rule: 'my-rule',
+        message: 'Description of the issue',
         line: path.node.loc?.start.line ?? 0,
         column: path.node.loc?.start.column ?? 0,
-        severity: "error", // or 'warning'
+        severity: 'error', // or 'warning'
       });
     },
   });
@@ -840,7 +840,7 @@ interface LintResult {
   message: string;
   line: number; // 1-indexed
   column: number; // 0-indexed
-  severity: "error" | "warning";
+  severity: 'error' | 'warning';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -770,15 +770,7 @@ function createUser(name: string, email: string, age: number) {
 }
 
 // Good - named parameters via object destructuring
-function createUser({
-  name,
-  email,
-  age,
-}: {
-  name: string;
-  email: string;
-  age: number;
-}) {
+function createUser({ name, email, age }: { name: string; email: string; age: number }) {
   return { name, email, age };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const webRules = getRulesForPlatform('web');
 const backendRules = getRulesForPlatform('backend');
 ```
 
-## Available Rules (50 total)
+## Available Rules (51 total)
 
 ### Expo Router Rules
 
@@ -155,6 +155,7 @@ const backendRules = getRulesForPlatform('backend');
 | ---------------------------- | -------- | -------- | ----------------------------------------------------------------- |
 | `require-use-client`         | error    | web      | Files using client-only features must have "use client" directive |
 | `no-server-import-in-client` | error    | web      | "use client" files must not import server-only modules            |
+| `no-module-level-new`        | error    | web      | Don't use `new` at module scope (crashes during SSR)              |
 
 ### React / JSX Rules
 

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ const backendRules = getRulesForPlatform('backend');
 
 ### General Rules
 
-| Rule                  | Severity | Platform  | Description                                   |
-| --------------------- | -------- | --------- | --------------------------------------------- |
-| `prefer-lucide-icons` | warning  | expo, web | Prefer lucide-react/lucide-react-native icons |
-| `no-module-level-new`        | error    | web      | Don't use `new` at module scope (crashes during SSR)              |
+| Rule                  | Severity | Platform  | Description                                          |
+| --------------------- | -------- | --------- | ---------------------------------------------------- |
+| `prefer-lucide-icons` | warning  | expo, web | Prefer lucide-react/lucide-react-native icons        |
+| `no-module-level-new` | error    | web       | Don't use `new` at module scope (crashes during SSR) |
 
 ---
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -49,6 +49,7 @@ import { noSyncFs } from './no-sync-fs';
 import { preferNamedParams } from './prefer-named-params';
 import { requireUseClient } from './require-use-client';
 import { noServerImportInClient } from './no-server-import-in-client';
+import { noModuleLevelNew } from './no-module-level-new';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -101,4 +102,5 @@ export const rules: Record<string, RuleFunction> = {
   'prefer-named-params': preferNamedParams,
   'require-use-client': requireUseClient,
   'no-server-import-in-client': noServerImportInClient,
+  'no-module-level-new': noModuleLevelNew,
 };

--- a/src/rules/meta.ts
+++ b/src/rules/meta.ts
@@ -32,6 +32,7 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
   'no-tailwind-animation-classes': ['web'],
   'require-use-client': ['web'],
   'no-server-import-in-client': ['web'],
+  'no-module-level-new': ['web'],
 
   // Expo + Web (shared frontend)
   'no-relative-paths': ['expo', 'web'],

--- a/src/rules/no-module-level-new.ts
+++ b/src/rules/no-module-level-new.ts
@@ -1,0 +1,95 @@
+import traverse from '@babel/traverse';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-module-level-new';
+
+const SAFE_CONSTRUCTORS = new Set([
+  'Error',
+  'TypeError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'URIError',
+  'URL',
+  'URLSearchParams',
+  'RegExp',
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'Date',
+  'Promise',
+  'Int8Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'BigInt64Array',
+  'BigUint64Array',
+  'ArrayBuffer',
+  'SharedArrayBuffer',
+  'DataView',
+  'TextEncoder',
+  'TextDecoder',
+]);
+
+export function noModuleLevelNew(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  traverse(ast, {
+    NewExpression(path) {
+      const { callee, loc } = path.node;
+
+      let name: string;
+      if (callee.type === 'Identifier') {
+        name = callee.name;
+      } else if (
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier'
+      ) {
+        name = `${callee.object.name}.${
+          callee.property.type === 'Identifier' ? callee.property.name : '...'
+        }`;
+      } else {
+        name = 'Expression';
+      }
+
+      if (SAFE_CONSTRUCTORS.has(name)) {
+        return;
+      }
+
+      let currentPath = path.parentPath;
+      while (currentPath) {
+        const { type } = currentPath.node;
+        if (
+          type === 'FunctionDeclaration' ||
+          type === 'FunctionExpression' ||
+          type === 'ArrowFunctionExpression' ||
+          type === 'ClassDeclaration' ||
+          type === 'ClassExpression' ||
+          type === 'ClassMethod' ||
+          type === 'ClassPrivateMethod' ||
+          type === 'ObjectMethod'
+        ) {
+          return;
+        }
+        currentPath = currentPath.parentPath as typeof currentPath;
+      }
+
+      results.push({
+        rule: RULE_NAME,
+        message: `\`new ${name}()\` at module level will execute during SSR and may crash or cause side effects. Move it inside a component, useEffect, or wrap it in a factory function.`,
+        line: loc?.start.line ?? 0,
+        column: loc?.start.column ?? 0,
+        severity: 'error',
+      });
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-module-level-new.ts
+++ b/src/rules/no-module-level-new.ts
@@ -48,10 +48,7 @@ export function noModuleLevelNew(ast: File, _code: string): LintResult[] {
       let name: string;
       if (callee.type === 'Identifier') {
         name = callee.name;
-      } else if (
-        callee.type === 'MemberExpression' &&
-        callee.object.type === 'Identifier'
-      ) {
+      } else if (callee.type === 'MemberExpression' && callee.object.type === 'Identifier') {
         name = `${callee.object.name}.${
           callee.property.type === 'Identifier' ? callee.property.name : '...'
         }`;

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(50);
+      expect(ruleNames.length).toBe(51);
     });
   });
 });

--- a/tests/no-module-level-new.test.ts
+++ b/tests/no-module-level-new.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-module-level-new'] };
+
+describe('no-module-level-new rule', () => {
+  it('should flag new QueryClient() at module level', () => {
+    const code = `
+      import { QueryClient } from '@tanstack/react-query';
+      const queryClient = new QueryClient();
+      export default function Layout({ children }) {
+        return <div>{children}</div>;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-module-level-new');
+    expect(results[0].message).toContain('new QueryClient()');
+    expect(results[0].severity).toBe('error');
+  });
+
+  it('should flag new IntersectionObserver() at module level', () => {
+    const code = `
+      const observer = new IntersectionObserver(callback);
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('IntersectionObserver');
+  });
+
+  it('should flag unknown constructors at module level', () => {
+    const code = `
+      const thing = new SomeUnknownClass();
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain('SomeUnknownClass');
+  });
+
+  it('should not flag new QueryClient() inside a function body', () => {
+    const code = `
+      function createClient() {
+        return new QueryClient();
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new QueryClient() inside useEffect callback', () => {
+    const code = `
+      function Component() {
+        useEffect(() => {
+          const qc = new QueryClient();
+        }, []);
+        return <div>Hello</div>;
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new QueryClient() inside arrow function', () => {
+    const code = `
+      const makeClient = () => {
+        return new QueryClient();
+      };
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new Error() at module level', () => {
+    const code = `
+      const NOT_FOUND = new Error('Not found');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new URL() at module level', () => {
+    const code = `
+      const baseUrl = new URL('https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new Map() at module level', () => {
+    const code = `
+      const cache = new Map();
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new RegExp() at module level', () => {
+    const code = `
+      const pattern = new RegExp('\\\\d+');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new Set() at module level', () => {
+    const code = `
+      const seen = new Set();
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag new Date() at module level', () => {
+    const code = `
+      const start = new Date();
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag constructors inside class methods', () => {
+    const code = `
+      class MyService {
+        init() {
+          this.client = new QueryClient();
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag constructors inside class bodies via property initializer', () => {
+    const code = `
+      class MyService {
+        createClient() {
+          return new QueryClient();
+        }
+      }
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should flag multiple module-level new expressions', () => {
+    const code = `
+      const a = new QueryClient();
+      const b = new WebSocket('ws://localhost');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `no-module-level-new` lint rule that detects `new Expression()` calls at module scope, which execute during SSR and may crash or cause side effects
- Allows safe constructors (Error, URL, Map, Set, RegExp, Date, TextEncoder, etc.) while flagging SSR-unsafe ones like QueryClient, IntersectionObserver, WebSocket
- Tagged as `web` platform rule

Motivated by a design agent failure where `const queryClient = new QueryClient()` at module level in `layout.jsx` compiled fine but crashed at SSR runtime, causing blank screenshots and an ~8 minute debugging loop.

## Manual QA Plan

| Scenario | Action | Expected |
|----------|--------|----------|
| Module-level unsafe new | Lint `const qc = new QueryClient()` at top level | Error reported |
| Safe constructor | Lint `const m = new Map()` at top level | No error |
| Inside function | Lint `function f() { new QueryClient() }` | No error |
| Inside useEffect | Lint `useEffect(() => { new QueryClient() })` | No error |
| Full suite | `npm test` | All 416 tests pass |