### PR TITLE
feat: add no-deprecated-url-parse lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,13 @@ const backendRules = getRulesForPlatform('backend');
 
 ### General Rules
 
-| Rule                     | Severity | Platform  | Description                                                    |
-| ------------------------ | -------- | --------- | -------------------------------------------------------------- |
-| `prefer-lucide-icons`    | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
-| `no-react-native-in-web` | error    | web       | Don't import react-native in web modules (causes ESM failures) |
-| `prefer-lucide-icons`    | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
-| `no-module-level-new`    | error    | web       | Don't use `new` at module scope (crashes during SSR)           |
+| Rule                      | Severity | Platform  | Description                                                    |
+| ------------------------- | -------- | --------- | -------------------------------------------------------------- |
+| `prefer-lucide-icons`     | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
+| `no-react-native-in-web`  | error    | web       | Don't import react-native in web modules (causes ESM failures) |
+| `prefer-lucide-icons`     | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
+| `no-module-level-new`     | error    | web       | Don't use `new` at module scope (crashes during SSR)           |
+| `no-deprecated-url-parse` | warning  | backend   | Use `new URL()` instead of deprecated `url.parse()`            |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ const backendRules = getRulesForPlatform('backend');
 | `sql-no-nested-calls`                | error    | backend   | Don't nest sql template tags                                     |
 | `no-sync-fs`                         | error    | backend   | Use fs.promises or fs/promises instead of sync fs methods        |
 | `no-unrestricted-loop-in-serverless` | error    | backend   | Unbounded loops (while(true), for(;;)) cause serverless timeouts |
-| `prefer-lucide-icons`     | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
-| `no-react-native-in-web`  | error    | web       | Don't import react-native in web modules (causes ESM failures) |
-| `prefer-lucide-icons`     | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                  |
-| `no-module-level-new`     | error    | web       | Don't use `new` at module scope (crashes during SSR)           |
-| `no-deprecated-url-parse` | warning  | backend   | Use `new URL()` instead of deprecated `url.parse()`            |
+| `prefer-lucide-icons`                | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                    |
+| `no-react-native-in-web`             | error    | web       | Don't import react-native in web modules (causes ESM failures)   |
+| `prefer-lucide-icons`                | warning  | expo, web | Prefer lucide-react/lucide-react-native icons                    |
+| `no-module-level-new`                | error    | web       | Don't use `new` at module scope (crashes during SSR)             |
+| `no-deprecated-url-parse`            | warning  | backend   | Use `new URL()` instead of deprecated `url.parse()`              |
 
 ---
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -52,6 +52,7 @@ import { noServerImportInClient } from './no-server-import-in-client';
 import { ssrBrowserApiGuard } from './ssr-browser-api-guard';
 import { noReactNativeInWeb } from './no-react-native-in-web';
 import { noModuleLevelNew } from './no-module-level-new';
+import { noDeprecatedUrlParse } from './no-deprecated-url-parse';
 
 export const rules: Record<string, RuleFunction> = {
   'no-relative-paths': noRelativePaths,
@@ -107,4 +108,5 @@ export const rules: Record<string, RuleFunction> = {
   'ssr-browser-api-guard': ssrBrowserApiGuard,
   'no-react-native-in-web': noReactNativeInWeb,
   'no-module-level-new': noModuleLevelNew,
+  'no-deprecated-url-parse': noDeprecatedUrlParse,
 };

--- a/src/rules/meta.ts
+++ b/src/rules/meta.ts
@@ -51,6 +51,7 @@ export const rulePlatforms: Partial<Record<string, Platform[]>> = {
   'no-response-json-lowercase': ['backend'],
   'sql-no-nested-calls': ['backend'],
   'no-sync-fs': ['backend'],
+  'no-deprecated-url-parse': ['backend'],
 
   // Universal rules (NOT listed here): prefer-guard-clauses, no-type-assertion,
   // no-string-coerce-error

--- a/src/rules/no-deprecated-url-parse.ts
+++ b/src/rules/no-deprecated-url-parse.ts
@@ -1,0 +1,73 @@
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import type { File } from '@babel/types';
+import type { LintResult } from '../types';
+
+const RULE_NAME = 'no-deprecated-url-parse';
+
+export function noDeprecatedUrlParse(ast: File, _code: string): LintResult[] {
+  const results: LintResult[] = [];
+
+  // Track identifiers imported/required from 'url' or 'node:url'
+  const urlImportedNames = new Set<string>();
+
+  traverse(ast, {
+    ImportDeclaration(path) {
+      const source = path.node.source.value;
+      if (source !== 'url' && source !== 'node:url') return;
+
+      for (const specifier of path.node.specifiers) {
+        if (t.isImportSpecifier(specifier) && t.isIdentifier(specifier.local)) {
+          const imported = t.isIdentifier(specifier.imported)
+            ? specifier.imported.name
+            : specifier.imported.value;
+          if (imported === 'parse') {
+            urlImportedNames.add(specifier.local.name);
+          }
+        }
+        if (t.isImportDefaultSpecifier(specifier) || t.isImportNamespaceSpecifier(specifier)) {
+          urlImportedNames.add(specifier.local.name);
+        }
+      }
+    },
+
+    CallExpression(path) {
+      const { callee, loc } = path.node;
+
+      // Pattern 1: url.parse(...)
+      if (
+        t.isMemberExpression(callee) &&
+        t.isIdentifier(callee.property) &&
+        callee.property.name === 'parse'
+      ) {
+        const objectName = t.isIdentifier(callee.object) ? callee.object.name : null;
+        if (
+          objectName === 'url' ||
+          objectName === 'URL' ||
+          urlImportedNames.has(objectName ?? '')
+        ) {
+          results.push({
+            rule: RULE_NAME,
+            message: "url.parse() is deprecated. Use 'new URL(input, base)' instead",
+            line: loc?.start.line ?? 0,
+            column: loc?.start.column ?? 0,
+            severity: 'warning',
+          });
+        }
+      }
+
+      // Pattern 2: parse(...) — direct named import from 'url'
+      if (t.isIdentifier(callee) && urlImportedNames.has(callee.name)) {
+        results.push({
+          rule: RULE_NAME,
+          message: "url.parse() is deprecated. Use 'new URL(input, base)' instead",
+          line: loc?.start.line ?? 0,
+          column: loc?.start.column ?? 0,
+          severity: 'warning',
+        });
+      }
+    },
+  });
+
+  return results;
+}

--- a/src/rules/no-deprecated-url-parse.ts
+++ b/src/rules/no-deprecated-url-parse.ts
@@ -41,11 +41,10 @@ export function noDeprecatedUrlParse(ast: File, _code: string): LintResult[] {
         callee.property.name === 'parse'
       ) {
         const objectName = t.isIdentifier(callee.object) ? callee.object.name : null;
-        if (
-          objectName === 'url' ||
-          objectName === 'URL' ||
-          urlImportedNames.has(objectName ?? '')
-        ) {
+        // Note: only the lowercase legacy `url` module is deprecated. `URL.parse`
+        // is the modern static method on the WHATWG URL constructor (Node 22+,
+        // browsers) and is a valid replacement — do not flag it.
+        if (objectName === 'url' || urlImportedNames.has(objectName ?? '')) {
           results.push({
             rule: RULE_NAME,
             message: "url.parse() is deprecated. Use 'new URL(input, base)' instead",

--- a/tests/config-modes.test.ts
+++ b/tests/config-modes.test.ts
@@ -123,7 +123,7 @@ describe('config modes', () => {
       expect(ruleNames).toContain('no-relative-paths');
       expect(ruleNames).toContain('expo-image-import');
       expect(ruleNames).toContain('no-stylesheet-create');
-      expect(ruleNames.length).toBe(53);
+      expect(ruleNames.length).toBe(54);
     });
   });
 });

--- a/tests/no-deprecated-url-parse.test.ts
+++ b/tests/no-deprecated-url-parse.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { lintJsxCode } from '../src';
+
+const config = { rules: ['no-deprecated-url-parse'] };
+
+describe('no-deprecated-url-parse rule', () => {
+  it('should detect url.parse() with default import', () => {
+    const code = `
+      import url from 'url';
+      const parsed = url.parse('https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe('no-deprecated-url-parse');
+    expect(results[0].message).toContain('deprecated');
+    expect(results[0].message).toContain('new URL');
+    expect(results[0].severity).toBe('warning');
+  });
+
+  it('should detect url.parse() with namespace import', () => {
+    const code = `
+      import * as url from 'node:url';
+      const parsed = url.parse(req.url);
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect named import of parse from url', () => {
+    const code = `
+      import { parse } from 'url';
+      const parsed = parse('https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should detect aliased named import', () => {
+    const code = `
+      import { parse as urlParse } from 'url';
+      const parsed = urlParse('https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(1);
+  });
+
+  it('should allow new URL()', () => {
+    const code = `
+      const parsed = new URL('https://example.com');
+      const withBase = new URL('/path', 'https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should allow url.format() and other url methods', () => {
+    const code = `
+      import url from 'url';
+      const formatted = url.format({ protocol: 'https', hostname: 'example.com' });
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not flag parse() from non-url modules', () => {
+    const code = `
+      import { parse } from 'path';
+      const result = parse('/foo/bar.txt');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/no-deprecated-url-parse.test.ts
+++ b/tests/no-deprecated-url-parse.test.ts
@@ -70,4 +70,12 @@ describe('no-deprecated-url-parse rule', () => {
     const results = lintJsxCode(code, config);
     expect(results).toHaveLength(0);
   });
+
+  it('should not flag URL.parse static method (modern WHATWG URL API)', () => {
+    const code = `
+      const result = URL.parse('https://example.com');
+    `;
+    const results = lintJsxCode(code, config);
+    expect(results).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `no-deprecated-url-parse` rule that detects usage of `url.parse()`, deprecated in Node.js
- Suggests using `new URL(input, base)` instead
- Handles default imports, namespace imports (`import * as url`), and named imports (`import { parse }`) from both `url` and `node:url`
- **619+ deprecation warnings/week** in production
- Platform: `backend` only

## Test plan
| Scenario | Expected |
|---|---|
| `url.parse('...')` with default import | Warning flagged |
| `url.parse('...')` with `import * as url from 'node:url'` | Warning flagged |
| `parse('...')` with `import { parse } from 'url'` | Warning flagged |
| `urlParse('...')` with `import { parse as urlParse }` | Warning flagged |
| `new URL('...')` | No warning |
| `url.format(...)` | No warning |
| `parse()` from `path` module | No warning |