### PR TITLE
Support .js and .ts file extensions in CLI check

### DIFF
--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { lintJsxCode } from '../index';
 import type { LintConfig, LintResult } from '../types';
 
-const JSX_EXTENSIONS = new Set(['.jsx', '.tsx']);
+const LINT_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
 
 function loadConfig(): LintConfig {
   const configPath = path.resolve('laint.config.json');
@@ -55,7 +55,7 @@ async function runHookMode(): Promise<void> {
   }
 
   const ext = path.extname(filePath).toLowerCase();
-  if (!JSX_EXTENSIONS.has(ext)) {
+  if (!LINT_EXTENSIONS.has(ext)) {
     process.exit(0);
   }
 


### PR DESCRIPTION
The babel parser already has `typescript` and `jsx` plugins enabled, and many rules (e.g. `no-type-assertion`, `prefer-guard-clauses`, `safe-json-parse`) are pure TS rules with no JSX involved. The only thing blocking `.js`/`.ts` files was the extension filter in the CLI check command.

### Changes
- Added `.js` and `.ts` to the supported file extensions in `src/cli/check.ts`

### Testing
All 401 existing tests pass.